### PR TITLE
Adding GPIO expander driver to makefile

### DIFF
--- a/Drivers/NER/include/pi4ioe.h
+++ b/Drivers/NER/include/pi4ioe.h
@@ -48,7 +48,7 @@ typedef struct
  * @param hi2c
  * @return HAL_StatusTypeDef 
  */
- HAL_StatusTypeDef PI4IOE_Init(pi4ioe_t *gpio, I2C_HandleTypeDef *hi2c);
+ HAL_StatusTypeDef pio4oe_init(pi4ioe_t *gpio, I2C_HandleTypeDef *hi2c);
 
 /**
  * @brief Writes to the PI4IOE5V9535ZDEX GPIO Expander
@@ -58,7 +58,7 @@ typedef struct
  * @param i2c_handle
  * @return HAL_StatusTypeDef 
  */
- HAL_StatusTypeDef PI4IOE_Write(uint8_t device, uint8_t val, I2C_HandleTypeDef *i2c_handle);
+ HAL_StatusTypeDef pio4oe_Write(uint8_t device, uint8_t val, I2C_HandleTypeDef *i2c_handle);
 
 /**
  * @brief Reads from the PI4IOE5V9535ZDEX GPIO Expander
@@ -67,7 +67,7 @@ typedef struct
  * @param buf
  * @param i2c_handle 
  */
- HAL_StatusTypeDef PI4IOE_Read(uint8_t *buf, I2C_HandleTypeDef *i2c_handle);
+ HAL_StatusTypeDef pio4oe_read(uint8_t *buf, I2C_HandleTypeDef *i2c_handle);
 
 
 #endif // PI4IOE_H

--- a/Drivers/NER/include/pi4ioe.h
+++ b/Drivers/NER/include/pi4ioe.h
@@ -58,7 +58,7 @@ typedef struct
  * @param i2c_handle
  * @return HAL_StatusTypeDef 
  */
- HAL_StatusTypeDef pio4oe_Write(uint8_t device, uint8_t val, I2C_HandleTypeDef *i2c_handle);
+ HAL_StatusTypeDef pio4oe_write(uint8_t device, uint8_t val, I2C_HandleTypeDef *i2c_handle);
 
 /**
  * @brief Reads from the PI4IOE5V9535ZDEX GPIO Expander

--- a/Drivers/NER/src/pi4ioe.c
+++ b/Drivers/NER/src/pi4ioe.c
@@ -18,7 +18,7 @@ HAL_StatusTypeDef pi4ioe_init(pi4ioe_t *gpio, I2C_HandleTypeDef *i2c_handle)
 	return HAL_I2C_Master_Transmit(i2c_handle, PI4IOE_I2C_ADDR, buf, 2, HAL_MAX_DELAY);
 }
 
- HAL_StatusTypeDef PI4IOE_Write(uint8_t device, uint8_t val, I2C_HandleTypeDef *i2c_handle)
+ HAL_StatusTypeDef pio4oe_write(uint8_t device, uint8_t val, I2C_HandleTypeDef *i2c_handle)
  {
 	uint8_t reg;
 
@@ -30,7 +30,7 @@ HAL_StatusTypeDef pi4ioe_init(pi4ioe_t *gpio, I2C_HandleTypeDef *i2c_handle)
 
  }
 
-  HAL_StatusTypeDef PI4IOE_Read(uint8_t *buf, I2C_HandleTypeDef *i2c_handle)
+  HAL_StatusTypeDef pio4oe_read(uint8_t *buf, I2C_HandleTypeDef *i2c_handle)
   {
 	uint8_t reg = INPUT0_REG;
 	

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_spi.c \
 Drivers/NER/src/lsm6dso.c \
 Drivers/NER/src/sht30.c \
 Drivers/NER/src/can.c \
+Drivers/NER/src/pi4ioe.c \
 Core/Src/system_stm32f4xx.c \
 Middlewares/Third_Party/FreeRTOS/Source/croutine.c \
 Middlewares/Third_Party/FreeRTOS/Source/event_groups.c \


### PR DESCRIPTION
Just adding some residual code to ensure that the GPIO expander driver is built into Cerberus