### PR TITLE
Beginning of Renode Testing

### DIFF
--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -19,6 +19,7 @@
 /* Includes ------------------------------------------------------------------*/
 #include "main.h"
 #include "cmsis_os.h"
+#include "sht30.h"
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
@@ -48,6 +49,8 @@ I2C_HandleTypeDef hi2c2;
 
 SPI_HandleTypeDef hspi1;
 SPI_HandleTypeDef hspi2;
+
+sht30_t temp_sensor;
 
 /* Definitions for defaultTask */
 osThreadId_t defaultTaskHandle;
@@ -113,6 +116,9 @@ int main(void)
   MX_SPI1_Init();
   MX_SPI2_Init();
   /* USER CODE BEGIN 2 */
+
+  //if(sht30_init(&temp_sensor, &hi2c1))
+    //Error_Handler();
 
   /* USER CODE END 2 */
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ RUN apt-get install -y \
     libusb-1.0-0-dev \
     pkg-config
 
-RUN git clone https://github.com/raspberrypi/openocd.git \
-    --branch rp2040 \
+RUN git clone https://github.com/STMicroelectronics/openocd.git \
+    --branch openocd-cubeide-r6 \
     --depth=1 \
     --no-single-branch
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,10 @@ RUN cd openocd && ./bootstrap
 RUN cd openocd && ./configure
 RUN cd openocd && make -j4 && make install
 
+RUN wget https://builds.renode.io/renode-1.13.3+20230712gitedfc975b.linux-portable.tar.gz
+RUN mkdir renode_portable && tar -xvf renode-*.linux-portable.tar.gz -C renode_portable --strip-components=1
+ENV PATH $PATH:/renode_portable
+
 # Set up a development tools directory
 WORKDIR /home/dev
 ADD . /home/dev

--- a/Drivers/NER/include/sht30.h
+++ b/Drivers/NER/include/sht30.h
@@ -42,7 +42,7 @@ typedef struct
  * @param sht30 
  * @return HAL_StatusTypeDef 
  */
-HAL_StatusTypeDef sht30_init(sht30_t *sht30);
+HAL_StatusTypeDef sht30_init(sht30_t *sht30, I2C_HandleTypeDef *hi2c);
 
 /**
  * @brief Resets the SHT30 chip

--- a/Drivers/NER/src/sht30.c
+++ b/Drivers/NER/src/sht30.c
@@ -6,7 +6,7 @@
 
 static HAL_StatusTypeDef sht30_read_reg(sht30_t *sht30, uint8_t *data, uint16_t reg, uint8_t size)
 {
-    return HAL_I2C_Mem_Write(sht30->i2c_handle, SHT30_I2C_ADDR, reg, I2C_MEMADD_SIZE_16BIT, data, size, HAL_MAX_DELAY);
+    return HAL_I2C_Mem_Read(sht30->i2c_handle, SHT30_I2C_ADDR, reg, I2C_MEMADD_SIZE_16BIT, data, size, HAL_MAX_DELAY);
 }
 
 static HAL_StatusTypeDef sht30_write_reg(sht30_t *sht30, uint16_t reg, uint8_t *data, uint8_t size)
@@ -59,9 +59,11 @@ HAL_StatusTypeDef sht30_reset(sht30_t *sht30)
     return sht30_write_reg(sht30, SWITCHBYTES(SHT30_SOFTRESET), 0, 2);
 }
 
-HAL_StatusTypeDef sht30_init(sht30_t *sht30)
+HAL_StatusTypeDef sht30_init(sht30_t *sht30, I2C_HandleTypeDef *hi2c)
 {
     HAL_StatusTypeDef status;
+
+    sht30->i2c_handle = hi2c;
 
     status = sht30_reset(sht30);
     if (status != HAL_OK)

--- a/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_can.c
+++ b/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_can.c
@@ -330,6 +330,9 @@ HAL_StatusTypeDef HAL_CAN_Init(CAN_HandleTypeDef *hcan)
   }
 #endif /* (USE_HAL_CAN_REGISTER_CALLBACKS) */
 
+  /* Exit from sleep mode */
+  CLEAR_BIT(hcan->Instance->MCR, CAN_MCR_SLEEP);
+
   /* Request initialisation */
   SET_BIT(hcan->Instance->MCR, CAN_MCR_INRQ);
 
@@ -350,9 +353,6 @@ HAL_StatusTypeDef HAL_CAN_Init(CAN_HandleTypeDef *hcan)
       return HAL_ERROR;
     }
   }
-
-  /* Exit from sleep mode */
-  CLEAR_BIT(hcan->Instance->MCR, CAN_MCR_SLEEP);
 
   /* Get tick */
   tickstart = HAL_GetTick();

--- a/README.md
+++ b/README.md
@@ -1,40 +1,63 @@
 # Cerberus
-FreeRTOS Application that runs on MPU22A
+> FreeRTOS Application that runs on MPU22A
 
 ## Setting up Docker Environment
-For initial installation, visit here: https://nerdocs.atlassian.net/wiki/spaces/NER/pages/108888108/Setting+Up+STM32+Dev+Env
+> For initial installation, visit here: https://nerdocs.atlassian.net/wiki/spaces/NER/pages/108888108/Setting+Up+STM32+Dev+Env
 
-## Start Container on MacOS/Linux
-In any terminal that is in the directory:
+```
+# TLDR:
+# Pull Container:
+docker pull nwdepatie/ner-gcc-arm
 
-    # if need to rebuild image
-    docker image prune -a
-    sudo docker build -f ./Dockerfile -t ner-gcc-arm .
+# Run Container
+# macOS: 
+docker run --rm -it --privileged -v "$PWD:/home/app" ner-gcc-arm:latest bash
 
-    sudo docker run --rm -it --privileged -v "$PWD:/home/app" ner-gcc-arm:latest bash
-    
-## Start Container on Windows
-In any terminal that is in the directory:
+# Windows
+docker run --rm -it --privileged -v "$(PWD):/home/app" ner-gcc-arm:latest bash
 
-    # if need to rebuild image
-    docker image prune -a
-    docker build -f ./Dockerfile -t ner-gcc-arm .
+# Linux
+sudo docker run --rm -it --privileged -v "$PWD:/home/app" ner-gcc-arm:latest bash
+```
 
-    docker run --rm -it --privileged -v "$(PWD):/home/app" ner-gcc-arm:latest bash
-
-    # mounting probe
-    # in another terminal run wsl -d ubuntu
-    usbipd wsl list
-    usbipd wsl attach --distribution=ubuntu --busid=<BUSID>
-    # close the other wsl window, the device should be mounted to any wsl instance
-    
+## Container Tools and Utilities
+> This container is packed with tools that can be utilized by developers to give them more insight into their developed software
+```
 ## Tools / Utils
 
-    # to build project
-    make all
+# to build project
+make all
 
-    # to open a serial port (make sure /dev/tty0/ACM0 exists first)
-    minicom -b 115200 -o -D /dev/ttyACM0
+# to run Renode emulation
+renode
+i @cerberus.resc
+start
 
-    # to flash STM board with Raspberry Pi Probe (WIP)
-    openocd -f interface/cmsis-dap.cfg -f target/stm32f4x.cfg -c "adapter speed 5000" -c "program ./build/cerberus.elf verify reset exit"
+# to open a serial port with Rasberry Pi Probe (make sure /dev/tty0/ACM0 exists first)
+minicom -b 115200 -o -D /dev/ttyACM0
+
+# to flash STM board with Raspberry Pi Probe (WIP)
+openocd -f interface/cmsis-dap.cfg -f target/stm32f4x.cfg -c "adapter speed 5000" -c "program ./build/cerberus.elf verify reset exit"
+```
+### Mounting Hardware to Docker Container in Windows
+> Very specific use case but nonetheless needed, also documented in the above confluence page, on macOS and Linux this happens by default when running privileged docker container
+```
+# Connect probe and open two terminals
+
+# Terminal 1:
+wsl -d ubuntu
+
+# Terminal 2
+usbipd wsl list
+usbipd wsl attach --distribution=ubuntu --busid=<BUSID> # Terminal might need to be elevated to admin privileges for this
+
+# Close the other wsl window, the device should be mounted to any WSL instance
+# Start docker container
+```
+## Building Docker Container
+>  Typically this isn't needed unless making local changes to Dockerfile, please default to the first method via pulling the docker container
+```
+# if need to rebuild image
+sudo docker image prune -a
+sudo docker build -f ./Dockerfile -t ner-gcc-arm .
+```

--- a/Test/renode/mpu.repl
+++ b/Test/renode/mpu.repl
@@ -1,0 +1,3 @@
+using "platforms/cpus/stm32f405.repl"
+
+sht30: SHT30 @ i2c1 0x80

--- a/Test/renode/stm32f405.repl
+++ b/Test/renode/stm32f405.repl
@@ -1,0 +1,13 @@
+using "platforms/cpus/stm32f4.repl"
+
+i2c3: I2C.STM32F4_I2C @ sysbus 0x40005C00
+    EventInterrupt -> nvic@72
+    ErrorInterrupt -> nvic@73
+
+i2c2: I2C.STM32F4_I2C @ sysbus 0x40005800
+    EventInterrupt -> nvic@33
+    ErrorInterrupt -> nvic@34
+
+i2c1: I2C.STM32F4_I2C @ sysbus 0x40005400
+    EventInterrupt -> nvic@31
+    ErrorInterrupt -> nvic@32

--- a/cerberus.resc
+++ b/cerberus.resc
@@ -1,0 +1,12 @@
+:name: Cerberus Simulation
+:description: This runs the Cerberus FreeRTOS application using a precompiled ELF
+
+using sysbus
+
+mach create
+machine LoadPlatformDescription @test/renode/stm32f405.repl
+sysbus.cpu LogFunctionNames true
+sysbus LogAllPeripheralsAccess true
+
+sysbus LoadELF @build/cerberus.elf
+


### PR DESCRIPTION
Basically this serves as the start of using renode to simulate embedded code entirely in software so we don't have to upload to the car every time to test if code will brick the car or not. Renode also can provide a call stack and show peripheral interactions. I had to manually set a bit low in the STM32 HAL to get this to work so we should def try this out on hardware before merging but this feels very very promising.[ Details on how to run can be found in here](https://nerdocs.atlassian.net/wiki/spaces/NER/pages/158171269/Renode), everything should be built into the docker dev container.

Next step is to create peripherals. I think that this might need to happen in C# so I might need to learn some C# but there are a lot of references in the renode repos.