### PR TITLE
Motor Controller Driver (#10)

### DIFF
--- a/Drivers/NER/include/can.h
+++ b/Drivers/NER/include/can.h
@@ -24,6 +24,7 @@
 #include <stdint.h>
 #include "stm32f4xx_hal.h"
 #include "can_config.h"
+#include "cascadiamc.h"
 
 /* CAN Message type this holds all useful CAN information */
 typedef struct

--- a/Drivers/NER/include/cascadiamc.h
+++ b/Drivers/NER/include/cascadiamc.h
@@ -30,58 +30,58 @@ typedef struct
     int8_t throttle_signal; /* SCALE: 1         UNITS: Percentage             */
     int8_t brake_signal;    /* SCALE: 1         UNITS: Percentage             */
     int8_t drive_enable;    /* SCALE: 1         UNITS: No units just a number */
-} mc_t;
+} cascadiamc_t;
 
-mc_t* MC;
+cascadiamc_t_t* cascadiamc;
 
-void MC_init(mc_t* mc);
+void cascadiamc_init(cascadiamc_t* mc);
 
-void MC_update(mc_t* mc);
+void cascadiamc_update(cascadiamc_t* mc);
 
-int32_t MC_get_rpm(mc_t* mc);
+int32_t cascadiamc_get_rpm(cascadiamc_t* mc);
 
-int16_t MC_get_duty_cycle(mc_t* mc);
+int16_t cascadiamc_get_duty_cycle(cascadiamc_t* mc);
 
-int16_t MC_get_input_voltage(mc_t* mc);
+int16_t cascadiamc_get_input_voltage(cascadiamc_t* mc);
 
-int16_t MC_get_ac_current(mc_t* mc);
+int16_t cascadiamc_get_ac_current(cascadiamc_t* mc);
 
-int16_t MC_get_dc_current(mc_t* mc);
+int16_t cascadiamc_get_dc_current(cascadiamc_t* mc);
 
-int16_t MC_get_controller_temp(mc_t* mc);
+int16_t cascadiamc_get_controller_temp(cascadiamc_t* mc);
 
-int16_t MC_get_motor_temp(mc_t* mc);
+int16_t cascadiamc_get_motor_temp(cascadiamc_t* mc);
 
-uint8_t MC_get_fault_code(mc_t* mc);
+uint8_t cascadiamc_get_fault_code(cascadiamc_t* mc);
 
-int8_t MC_get_throttle_signal(mc_t* mc);
+int8_t cascadiamc_get_throttle_signal(cascadiamc_t* mc);
 
-int8_t MC_get_brake_signal(mc_t* mc);
+int8_t cascadiamc_get_brake_signal(cascadiamc_t* mc);
 
-int8_t MC_get_drive_enable(mc_t* mc);
+int8_t cascadiamc_get_drive_enable(cascadiamc_t* mc);
 
-void MC_set_brake_current(int16_t brake_current);                   /* SCALE: 10          UNITS: Amps       */
+void cascadiamc_set_brake_current(int16_t brake_current);                   /* SCALE: 10          UNITS: Amps       */
 
-void MC_set_current(int16_t current);                               /* SCALE: 10          UNITS: Amps       */
+void cascadiamc_set_current(int16_t current);                               /* SCALE: 10          UNITS: Amps       */
 
-void MC_set_speed(int32_t rpm);                                     /* SCALE: 1           UNITS: RPM        */
+void cascadiamc_set_speed(int32_t rpm);                                     /* SCALE: 1           UNITS: RPM        */
 
-void MC_set_position(int16_t angle);                                /* SCALE: 10          UNITS: Degrees    */
+void cascadiamc_set_position(int16_t angle);                                /* SCALE: 10          UNITS: Degrees    */
 
-void MC_set_relative_current(int16_t relative_current);             /* SCALE: 10          UNITS: Percentage */
+void cascadiamc_set_relative_current(int16_t relative_current);             /* SCALE: 10          UNITS: Percentage */
 
-void MC_set_relative_brake_current(int16_t relative_brake_current); /* SCALE: 10          UNITS: Percentage */
+void cascadiamc_set_relative_brake_current(int16_t relative_brake_current); /* SCALE: 10          UNITS: Percentage */
 
-void MC_set_digital_output(uint8_t output, bool value);             /* SCALE: 1           UNITS: No units   */
+void cascadiamc_set_digital_output(uint8_t output, bool value);             /* SCALE: 1           UNITS: No units   */
 
-void MC_set_max_ac_current(int16_t current);                        /* SCALE: 10          UNITS: Amps       */
+void cascadiamc_set_max_ac_current(int16_t current);                        /* SCALE: 10          UNITS: Amps       */
 
-void MC_set_max_ac_brake_current(int16_t current);                  /* SCALE: 10          UNITS: Amps       */
+void cascadiamc_set_max_ac_brake_current(int16_t current);                  /* SCALE: 10          UNITS: Amps       */
 
-void MC_set_max_dc_current(int16_t current);                        /* SCALE: 10          UNITS: Amps       */
+void cascadiamc_set_max_dc_current(int16_t current);                        /* SCALE: 10          UNITS: Amps       */
 
-void MC_set_max_dc_brake_current(int16_t current);                  /* SCALE: 10          UNITS: Amps       */
+void cascadiamc_set_max_dc_brake_current(int16_t current);                  /* SCALE: 10          UNITS: Amps       */
 
-void MC_set_drive_enable(bool drive_enable);                        /* SCALE: 1           UNITS: No units   */
+void cascadiamc_set_drive_enable(bool drive_enable);                        /* SCALE: 1           UNITS: No units   */
 
 #endif

--- a/Drivers/NER/include/cascadiamc.h
+++ b/Drivers/NER/include/cascadiamc.h
@@ -1,0 +1,87 @@
+/**
+ * @file cascadiamc.h
+ * @author Hamza Iqbal
+ * @brief Driver to abstract sending and receiving CAN messages to control cascadia motor controller
+ * @version 0.1
+ * @date 2023-08-09
+ * 
+ * @copyright Copyright (c) 2023
+ * 
+ */
+
+#ifndef CASCADIAMC_H
+#define CASCADIAMC_H
+
+#include <stdint.h>
+#include "stm32f4xx_hal.h"
+#include "can.h"
+
+#define NUM_POLES
+typedef struct
+{
+    int32_t rpm;            /* SCALE: 1         UNITS: Rotations per Minute   */
+    int16_t duty_cycle;     /* SCALE: 10        UNITS: Percentage             */
+    int16_t input_voltage;  /* SCALE: 1         UNITS: Volts                  */
+    int16_t ac_current;     /* SCALE: 10        UNITS: Amps                   */
+    int16_t dc_current;     /* SCALE: 10        UNITS: Amps                   */
+    int16_t cont_temp;      /* SCALE: 10        UNITS: Degrees Celsius        */
+    int16_t motor_temp;     /* SCALE: 10        UNITS: Degrees Celsius        */
+    uint8_t fault_code;     /* SCALE: 1         UNITS: No units just a number */
+    int8_t throttle_signal; /* SCALE: 1         UNITS: Percentage             */
+    int8_t brake_signal;    /* SCALE: 1         UNITS: Percentage             */
+    int8_t drive_enable;    /* SCALE: 1         UNITS: No units just a number */
+} mc_t;
+
+mc_t* MC;
+
+void MC_init(mc_t* mc);
+
+void MC_update(mc_t* mc);
+
+int32_t MC_get_rpm(mc_t* mc);
+
+int16_t MC_get_duty_cycle(mc_t* mc);
+
+int16_t MC_get_input_voltage(mc_t* mc);
+
+int16_t MC_get_ac_current(mc_t* mc);
+
+int16_t MC_get_dc_current(mc_t* mc);
+
+int16_t MC_get_controller_temp(mc_t* mc);
+
+int16_t MC_get_motor_temp(mc_t* mc);
+
+uint8_t MC_get_fault_code(mc_t* mc);
+
+int8_t MC_get_throttle_signal(mc_t* mc);
+
+int8_t MC_get_brake_signal(mc_t* mc);
+
+int8_t MC_get_drive_enable(mc_t* mc);
+
+void MC_set_brake_current(int16_t brake_current);                   /* SCALE: 10          UNITS: Amps       */
+
+void MC_set_current(int16_t current);                               /* SCALE: 10          UNITS: Amps       */
+
+void MC_set_speed(int32_t rpm);                                     /* SCALE: 1           UNITS: RPM        */
+
+void MC_set_position(int16_t angle);                                /* SCALE: 10          UNITS: Degrees    */
+
+void MC_set_relative_current(int16_t relative_current);             /* SCALE: 10          UNITS: Percentage */
+
+void MC_set_relative_brake_current(int16_t relative_brake_current); /* SCALE: 10          UNITS: Percentage */
+
+void MC_set_digital_output(uint8_t output, bool value);             /* SCALE: 1           UNITS: No units   */
+
+void MC_set_max_ac_current(int16_t current);                        /* SCALE: 10          UNITS: Amps       */
+
+void MC_set_max_ac_brake_current(int16_t current);                  /* SCALE: 10          UNITS: Amps       */
+
+void MC_set_max_dc_current(int16_t current);                        /* SCALE: 10          UNITS: Amps       */
+
+void MC_set_max_dc_brake_current(int16_t current);                  /* SCALE: 10          UNITS: Amps       */
+
+void MC_set_drive_enable(bool drive_enable);                        /* SCALE: 1           UNITS: No units   */
+
+#endif

--- a/Drivers/NER/include/cascadiamc.h
+++ b/Drivers/NER/include/cascadiamc.h
@@ -33,7 +33,7 @@ typedef struct
     int8_t drive_enable;    /* SCALE: 1         UNITS: No units just a number */
 } cascadiamc_t;
 
-cascadiamc_t* cascadiamc;
+static cascadiamc_t* cascadiamc;
 
 void cascadiamc_init(cascadiamc_t* mc);
 

--- a/Drivers/NER/include/cascadiamc.h
+++ b/Drivers/NER/include/cascadiamc.h
@@ -33,7 +33,7 @@ typedef struct
     int8_t drive_enable;    /* SCALE: 1         UNITS: No units just a number */
 } cascadiamc_t;
 
-cascadiamc_t_t* cascadiamc;
+cascadiamc_t* cascadiamc;
 
 void cascadiamc_init(cascadiamc_t* mc);
 

--- a/Drivers/NER/include/cascadiamc.h
+++ b/Drivers/NER/include/cascadiamc.h
@@ -33,31 +33,7 @@ typedef struct
     int8_t drive_enable;    /* SCALE: 1         UNITS: No units just a number */
 } cascadiamc_t;
 
-static cascadiamc_t* cascadiamc;
-
 void cascadiamc_init(cascadiamc_t* mc);
-
-void cascadiamc_update(cascadiamc_t* mc,  can_msg_t message);
-
-int32_t cascadiamc_get_rpm(cascadiamc_t* mc);
-
-int16_t cascadiamc_get_duty_cycle(cascadiamc_t* mc);
-
-int16_t cascadiamc_get_input_voltage(cascadiamc_t* mc);
-
-int16_t cascadiamc_get_ac_current(cascadiamc_t* mc);
-
-int16_t cascadiamc_get_dc_current(cascadiamc_t* mc);
-
-int16_t cascadiamc_get_controller_temp(cascadiamc_t* mc);
-
-int16_t cascadiamc_get_motor_temp(cascadiamc_t* mc);
-
-uint8_t cascadiamc_get_fault_code(cascadiamc_t* mc);
-
-int8_t cascadiamc_get_throttle_signal(cascadiamc_t* mc);
-
-int8_t cascadiamc_get_brake_signal(cascadiamc_t* mc);
 
 /*
  * SCALE: bool
@@ -69,72 +45,72 @@ int8_t cascadiamc_get_drive_enable(cascadiamc_t* mc);
  * SCALE: 10
  * UNITS: Amps       
  */
-void cascadiamc_set_brake_current(int16_t brake_current);                   
+int8_t cascadiamc_set_brake_current(int16_t brake_current);                   
 
 /*
  * SCALE: 10
  * UNITS: Amps       
  */
-void cascadiamc_set_current(int16_t current);
+int8_t cascadiamc_set_current(int16_t current);
 
 /*
  * SCALE: 1
  * UNITS: RPM       
  */
-void cascadiamc_set_speed(int32_t rpm);               
+int8_t cascadiamc_set_speed(int32_t rpm);               
 
 /*
  * SCALE: 10
  * UNITS: Degrees     
  */
-void cascadiamc_set_position(int16_t angle);
+int8_t cascadiamc_set_position(int16_t angle);
 
 /*
  * SCALE: 10
  * UNITS: Percentage     
  */
-void cascadiamc_set_relative_current(int16_t relative_current);     
+int8_t cascadiamc_set_relative_current(int16_t relative_current);     
 
 /*
  * SCALE: 10
  * UNITS: Percentage       
  */
-void cascadiamc_set_relative_brake_current(int16_t relative_brake_current); 
+int8_t cascadiamc_set_relative_brake_current(int16_t relative_brake_current); 
 
 /*
  * SCALE: 1
  * UNITS: No units       
  */
-void cascadiamc_set_digital_output(uint8_t output, bool value);      
+int8_t cascadiamc_set_digital_output(uint8_t output, bool value);      
 
 /*
  * SCALE: 10
  * UNITS: Amps       
  */
-void cascadiamc_set_max_ac_current(int16_t current);                   
+int8_t cascadiamc_set_max_ac_current(int16_t current);                   
 
 /*
  * SCALE: 10
  * UNITS: Amps       
  */
-void cascadiamc_set_max_ac_brake_current(int16_t current);         
+int8_t cascadiamc_set_max_ac_brake_current(int16_t current);         
 
 /*
  * SCALE: 10
  * UNITS: Amps       
  */
-void cascadiamc_set_max_dc_current(int16_t current);                    
+uint8_t cascadiamc_set_max_dc_current(int16_t current);                    
 
 /*
  * SCALE: 10
  * UNITS: Amps       
  */
-void cascadiamc_set_max_dc_brake_current(int16_t current);                
+int8_t cascadiamc_set_max_dc_brake_current(int16_t current);                
 
 /*
  * SCALE: bool
  * UNITS: No units      
  */
-void cascadiamc_set_drive_enable(bool drive_enable);
+int8_t cascadiamc_set_drive_enable(bool drive_enable);
 
 #endif

--- a/Drivers/NER/include/cascadiamc.h
+++ b/Drivers/NER/include/cascadiamc.h
@@ -13,6 +13,7 @@
 #define CASCADIAMC_H
 
 #include <stdint.h>
+#include <stdbool.h>   
 #include "stm32f4xx_hal.h"
 #include "can.h"
 
@@ -36,7 +37,7 @@ cascadiamc_t_t* cascadiamc;
 
 void cascadiamc_init(cascadiamc_t* mc);
 
-void cascadiamc_update(cascadiamc_t* mc);
+void cascadiamc_update(cascadiamc_t* mc,  can_msg_t message);
 
 int32_t cascadiamc_get_rpm(cascadiamc_t* mc);
 
@@ -58,30 +59,82 @@ int8_t cascadiamc_get_throttle_signal(cascadiamc_t* mc);
 
 int8_t cascadiamc_get_brake_signal(cascadiamc_t* mc);
 
+/*
+ * SCALE: bool
+ * UNITS: No units      
+ */
 int8_t cascadiamc_get_drive_enable(cascadiamc_t* mc);
 
-void cascadiamc_set_brake_current(int16_t brake_current);                   /* SCALE: 10          UNITS: Amps       */
+/*
+ * SCALE: 10
+ * UNITS: Amps       
+ */
+void cascadiamc_set_brake_current(int16_t brake_current);                   
 
-void cascadiamc_set_current(int16_t current);                               /* SCALE: 10          UNITS: Amps       */
+/*
+ * SCALE: 10
+ * UNITS: Amps       
+ */
+void cascadiamc_set_current(int16_t current);
 
-void cascadiamc_set_speed(int32_t rpm);                                     /* SCALE: 1           UNITS: RPM        */
+/*
+ * SCALE: 1
+ * UNITS: RPM       
+ */
+void cascadiamc_set_speed(int32_t rpm);               
 
-void cascadiamc_set_position(int16_t angle);                                /* SCALE: 10          UNITS: Degrees    */
+/*
+ * SCALE: 10
+ * UNITS: Degrees     
+ */
+void cascadiamc_set_position(int16_t angle);
 
-void cascadiamc_set_relative_current(int16_t relative_current);             /* SCALE: 10          UNITS: Percentage */
+/*
+ * SCALE: 10
+ * UNITS: Percentage     
+ */
+void cascadiamc_set_relative_current(int16_t relative_current);     
 
-void cascadiamc_set_relative_brake_current(int16_t relative_brake_current); /* SCALE: 10          UNITS: Percentage */
+/*
+ * SCALE: 10
+ * UNITS: Percentage       
+ */
+void cascadiamc_set_relative_brake_current(int16_t relative_brake_current); 
 
-void cascadiamc_set_digital_output(uint8_t output, bool value);             /* SCALE: 1           UNITS: No units   */
+/*
+ * SCALE: 1
+ * UNITS: No units       
+ */
+void cascadiamc_set_digital_output(uint8_t output, bool value);      
 
-void cascadiamc_set_max_ac_current(int16_t current);                        /* SCALE: 10          UNITS: Amps       */
+/*
+ * SCALE: 10
+ * UNITS: Amps       
+ */
+void cascadiamc_set_max_ac_current(int16_t current);                   
 
-void cascadiamc_set_max_ac_brake_current(int16_t current);                  /* SCALE: 10          UNITS: Amps       */
+/*
+ * SCALE: 10
+ * UNITS: Amps       
+ */
+void cascadiamc_set_max_ac_brake_current(int16_t current);         
 
-void cascadiamc_set_max_dc_current(int16_t current);                        /* SCALE: 10          UNITS: Amps       */
+/*
+ * SCALE: 10
+ * UNITS: Amps       
+ */
+void cascadiamc_set_max_dc_current(int16_t current);                    
 
-void cascadiamc_set_max_dc_brake_current(int16_t current);                  /* SCALE: 10          UNITS: Amps       */
+/*
+ * SCALE: 10
+ * UNITS: Amps       
+ */
+void cascadiamc_set_max_dc_brake_current(int16_t current);                
 
-void cascadiamc_set_drive_enable(bool drive_enable);                        /* SCALE: 1           UNITS: No units   */
+/*
+ * SCALE: bool
+ * UNITS: No units      
+ */
+void cascadiamc_set_drive_enable(bool drive_enable);
 
 #endif

--- a/Drivers/NER/src/can.c
+++ b/Drivers/NER/src/can.c
@@ -346,14 +346,10 @@ void HAL_CAN_RxFifo1MsgPendingCallback(CAN_HandleTypeDef *hcan)
     new_msg.id = rx_header->StdId;
     switch(new_msg.id)
     {
-        case 0x2010:   
-            cascadiamc_update(MC, new_msg);
+        case 0x2010:  
         case 0x2110:    
-            cascadiamc_update(MC, new_msg);
         case 0x2210:    
-            cascadiamc_update(MC, new_msg);
         case 0x2310:    
-            cascadiamc_update(MC, new_msg);
         case 0x2410:    
             cascadiamc_update(MC, new_msg);
         default:

--- a/Drivers/NER/src/can.c
+++ b/Drivers/NER/src/can.c
@@ -316,7 +316,22 @@ void HAL_CAN_RxFifo0MsgPendingCallback(CAN_HandleTypeDef *hcan)
     HAL_CAN_GetRxMessage(hcan, CAN_RX_FIFO0, rx_header, new_msg.data);
     new_msg.len = rx_header->DLC;
     new_msg.id = rx_header->StdId;
-    enqueue(can1_incoming, new_msg);
+    switch(new_msg.id)
+    {
+        case 0x2010:   
+            MC_update(MC, new_msg);
+        case 0x2110:    
+            MC_update(MC, new_msg);
+        case 0x2210:    
+            MC_update(MC, new_msg);
+        case 0x2310:    
+            MC_update(MC, new_msg);
+        case 0x2410:    
+            MC_update(MC, new_msg);
+        default:
+            enqueue(can1_incoming, new_msg);
+    }
+    
     free(rx_header);
 }
 
@@ -325,11 +340,26 @@ void HAL_CAN_RxFifo1MsgPendingCallback(CAN_HandleTypeDef *hcan)
 {
     CAN_RxHeaderTypeDef* rx_header = malloc(sizeof(CAN_RxHeaderTypeDef));
     can_msg_t new_msg;
-    new_msg.line = CAN_LINE_2;
-    HAL_CAN_GetRxMessage(hcan, CAN_RX_FIFO1, rx_header, new_msg.data);
+    new_msg.line = CAN_LINE_1;
+    HAL_CAN_GetRxMessage(hcan, CAN_RX_FIFO0, rx_header, new_msg.data);
     new_msg.len = rx_header->DLC;
     new_msg.id = rx_header->StdId;
-    enqueue(can2_incoming, new_msg);
+    switch(new_msg.id)
+    {
+        case 0x2010:   
+            MC_update(MC, new_msg);
+        case 0x2110:    
+            MC_update(MC, new_msg);
+        case 0x2210:    
+            MC_update(MC, new_msg);
+        case 0x2310:    
+            MC_update(MC, new_msg);
+        case 0x2410:    
+            MC_update(MC, new_msg);
+        default:
+            enqueue(can1_incoming, new_msg);
+    }
+    
     free(rx_header);
 }
 

--- a/Drivers/NER/src/can.c
+++ b/Drivers/NER/src/can.c
@@ -326,11 +326,11 @@ void HAL_CAN_RxFifo1MsgPendingCallback(CAN_HandleTypeDef *hcan)
 {
     CAN_RxHeaderTypeDef* rx_header = malloc(sizeof(CAN_RxHeaderTypeDef));
     can_msg_t new_msg;
-    new_msg.line = CAN_LINE_1;
-    HAL_CAN_GetRxMessage(hcan, CAN_RX_FIFO0, rx_header, new_msg.data);
+    new_msg.line = CAN_LINE_2;
+    HAL_CAN_GetRxMessage(hcan, CAN_RX_FIF1, rx_header, new_msg.data);
     new_msg.len = rx_header->DLC;
     new_msg.id = rx_header->StdId;
-    enqueue(can1_incoming, new_msg);
+    enqueue(can2_incoming, new_msg);
     
     free(rx_header);
 }

--- a/Drivers/NER/src/can.c
+++ b/Drivers/NER/src/can.c
@@ -319,15 +319,15 @@ void HAL_CAN_RxFifo0MsgPendingCallback(CAN_HandleTypeDef *hcan)
     switch(new_msg.id)
     {
         case 0x2010:   
-            MC_update(MC, new_msg);
+            cascadiamc_update(MC, new_msg);
         case 0x2110:    
-            MC_update(MC, new_msg);
+            cascadiamc_update(MC, new_msg);
         case 0x2210:    
-            MC_update(MC, new_msg);
+            cascadiamc_update(MC, new_msg);
         case 0x2310:    
-            MC_update(MC, new_msg);
+            cascadiamc_update(MC, new_msg);
         case 0x2410:    
-            MC_update(MC, new_msg);
+            cascadiamc_update(MC, new_msg);
         default:
             enqueue(can1_incoming, new_msg);
     }
@@ -347,15 +347,15 @@ void HAL_CAN_RxFifo1MsgPendingCallback(CAN_HandleTypeDef *hcan)
     switch(new_msg.id)
     {
         case 0x2010:   
-            MC_update(MC, new_msg);
+            cascadiamc_update(MC, new_msg);
         case 0x2110:    
-            MC_update(MC, new_msg);
+            cascadiamc_update(MC, new_msg);
         case 0x2210:    
-            MC_update(MC, new_msg);
+            cascadiamc_update(MC, new_msg);
         case 0x2310:    
-            MC_update(MC, new_msg);
+            cascadiamc_update(MC, new_msg);
         case 0x2410:    
-            MC_update(MC, new_msg);
+            cascadiamc_update(MC, new_msg);
         default:
             enqueue(can1_incoming, new_msg);
     }

--- a/Drivers/NER/src/cascadiamc.c
+++ b/Drivers/NER/src/cascadiamc.c
@@ -16,85 +16,7 @@ void cascadiamc_init(cascadiamc_t* mc)
 
 }
 
-void cascadiamc_update(cascadiamc_t* mc, can_msg_t message)
-{
-    switch(message.id)
-    {
-        case 0x2010:    // The byte furthest to the right is a standin for now, should be the last 2 digits of serial number in hex
-            int32_t ERPM = message.data >> 32;
-            mc->rpm = ERPM / NUM_POLES;
-            mc->duty_cycle = ((message.data >> 16) & 0x00000000FFFF);
-            mc->input_voltage = message.data & 0x00000000FFFF;
-        case 0x2110:    // The byte furthest to the right is a standin for now, should be the last 2 digits of serial number in hex
-            mc->ac_current = message.data >> 48;
-            mc->dc_current = ((message.data >> 32) & 0x00000000FFFF);
-        case 0x2210:    // The byte furthest to the right is a standin for now, should be the last 2 digits of serial number in hex
-            mc->cont_temp = message.data >> 48;
-            mc->motor_temp = ((message.data >> 32) & 0x00000000FFFF);
-            mc->fault_code = ((message.data >> 24) & 0x0000000000FF);
-        case 0x2310:    // The byte furthest to the right is a standin for now, should be the last 2 digits of serial number in hex
-            mc->throttle_signal = message.data >> 56;
-            mc->brake_signal = ((message.data >> 48) & 0x0000000000FF);
-            mc->drive_enable = ((message.data >> 39) & 0x000000000001);
-    }
-}
-
-int32_t cascadiamc_get_rpm(cascadiamc_t* mc)
-{
-    return mc->rpm;
-}
-
-int16_t cascadiamc_get_duty_cycle(cascadiamc_t* mc)
-{
-    return mc->duty_cycle;
-}
-
-int16_t cascadiamc_get_input_voltage(cascadiamc_t* mc)
-{
-    return mc->input_voltage;
-}
-
-int16_t cascadiamc_get_ac_current(cascadiamc_t* mc)
-{
-    return mc->ac_current;
-}
-
-int16_t cascadiamc_get_dc_current(cascadiamc_t* mc)
-{
-    return mc->dc_current;
-}
-
-int16_t cascadiamc_get_controller_temp(cascadiamc_t* mc)
-{
-    return mc->cont_temp;
-}
-
-int16_t cascadiamc_get_motor_temp(cascadiamc_t* mc)
-{
-    return mc->motor_temp;
-}
-
-uint8_t cascadiamc_get_fault_code(cascadiamc_t* mc)
-{
-    return mc->fault_code;
-}
-
-int8_t cascadiamc_get_throttle_signal(cascadiamc_t* mc)
-{
-    return mc->throttle_signal;
-}
-
-int8_t cascadiamc_get_brake_signal(cascadiamc_t* mc)
-{
-    return mc->brake_signal;
-}
-
-int8_t cascadiamc_get_drive_enable(cascadiamc_t* mc)
-{
-    return mc->drive_enable;
-}
-
-void cascadiamc_set_current(int16_t current)                                /* SCALE: 10          UNITS: Amps       */
+int8_t cascadiamc_set_current(int16_t current)                                /* SCALE: 10          UNITS: Amps       */
 {
     union
     {
@@ -118,9 +40,12 @@ void cascadiamc_set_current(int16_t current)                                /* S
     current_msg.id = msg_id;
 
     CAN_StatusTypedef status = can_send_message(current_msg);
+
+    if(status != HAL_OK){return 1;}
+    else {return 0;}
 }
 
-void cascadiamc_set_brake_current(int16_t brake_current)                    /* SCALE: 10          UNITS: Amps       */
+int8_t cascadiamc_set_brake_current(int16_t brake_current)                    /* SCALE: 10          UNITS: Amps       */
 {
     union
     {
@@ -144,9 +69,12 @@ void cascadiamc_set_brake_current(int16_t brake_current)                    /* S
     brake_current_msg.id = msg_id;
 
     CAN_StatusTypedef status = can_send_message(brake_current_msg);
+
+    if(status != HAL_OK){return 1;}
+    else {return 0;}
 }
 
-void cascadiamc_set_speed(int32_t rpm)                                      /* SCALE: 1           UNITS: RPM        */
+int8_t cascadiamc_set_speed(int32_t rpm)                                      /* SCALE: 1           UNITS: RPM        */
 {
     union
     {
@@ -170,9 +98,12 @@ void cascadiamc_set_speed(int32_t rpm)                                      /* S
     current_msg.id = msg_id;
 
     CAN_StatusTypedef status = can_send_message(speed_msg);
+
+    if(status != HAL_OK){return 1;}
+    else {return 0;}
 }
 
-void cascadiamc_set_position(int16_t angle)                                 /* SCALE: 10          UNITS: Degrees    */
+int8_t cascadiamc_set_position(int16_t angle)                                 /* SCALE: 10          UNITS: Degrees    */
 {
     union
     {
@@ -196,9 +127,12 @@ void cascadiamc_set_position(int16_t angle)                                 /* S
     position_msg.id = msg_id;
 
     CAN_StatusTypedef status = can_send_message(current_msg);
+
+    if(status != HAL_OK){return 1;}
+    else {return 0;}
 }
 
-void cascadiamc_set_relative_current(int16_t relative_current)              /* SCALE: 10          UNITS: Percentage */
+int8_t cascadiamc_set_relative_current(int16_t relative_current)              /* SCALE: 10          UNITS: Percentage */
 {
     union
     {
@@ -222,9 +156,12 @@ void cascadiamc_set_relative_current(int16_t relative_current)              /* S
     relative_current_msg.id = msg_id;
 
     CAN_StatusTypedef status = can_send_message(relative_current_msg);
+
+    if(status != HAL_OK){return 1;}
+    else {return 0;}
 }
 
-void cascadiamc_set_relative_brake_current(int16_t relative_brake_current)  /* SCALE: 10          UNITS: Percentage */
+int8_t cascadiamc_set_relative_brake_current(int16_t relative_brake_current)  /* SCALE: 10          UNITS: Percentage */
 {
     union
     {
@@ -248,9 +185,12 @@ void cascadiamc_set_relative_brake_current(int16_t relative_brake_current)  /* S
     relative_brake_current_msg.id = msg_id;
 
     CAN_StatusTypedef status = can_send_message(relative_brake_current_msg);
+
+    if(status != HAL_OK){return 1;}
+    else {return 0;}
 }
 
-void cascadiamc_set_digital_output(uint8_t output, bool value)              /* SCALE: 1           UNITS: No units   */
+int8_t cascadiamc_set_digital_output(uint8_t output, bool value)              /* SCALE: 1           UNITS: No units   */
 {
     union
     {
@@ -274,9 +214,12 @@ void cascadiamc_set_digital_output(uint8_t output, bool value)              /* S
     digital_output_msg.id = msg_id;
 
     CAN_StatusTypedef status = can_send_message(digital_output_msg);
+
+    if(status != HAL_OK){return 1;}
+    else {return 0;}
 }
 
-void cascadiamc_set_max_ac_current(int16_t current)                         /* SCALE: 10          UNITS: Amps       */
+int8_t cascadiamc_set_max_ac_current(int16_t current)                         /* SCALE: 10          UNITS: Amps       */
 {
     union
     {
@@ -300,9 +243,12 @@ void cascadiamc_set_max_ac_current(int16_t current)                         /* S
     max_ac_current_msg.id = msg_id;
 
     CAN_StatusTypedef status = can_send_message(max_ac_current_msg);
+
+    if(status != HAL_OK){return 1;}
+    else {return 0;}
 }
 
-void cascadiamc_set_max_ac_brake_current(int16_t current)                   /* SCALE: 10          UNITS: Amps       */
+int8_t cascadiamc_set_max_ac_brake_current(int16_t current)                   /* SCALE: 10          UNITS: Amps       */
 {
     union
     {
@@ -326,9 +272,12 @@ void cascadiamc_set_max_ac_brake_current(int16_t current)                   /* S
     max_ac_brake_current_msg.id = msg_id;
 
     CAN_StatusTypedef status = can_send_message(max_ac_brake_current_msg);
+
+    if(status != HAL_OK){return 1;}
+    else {return 0;}
 }
 
-void cascadiamc_set_max_dc_current(int16_t current)                         /* SCALE: 10          UNITS: Amps       */
+int8_t cascadiamc_set_max_dc_current(int16_t current)                         /* SCALE: 10          UNITS: Amps       */
 {
     union
     {
@@ -352,9 +301,12 @@ void cascadiamc_set_max_dc_current(int16_t current)                         /* S
     max_dc_current_msg.id = msg_id;
 
     CAN_StatusTypedef status = can_send_message(max_dc_current_msg);
+
+    if(status != HAL_OK){return 1;}
+    else {return 0;}
 }
 
-void cascadiamc_set_max_dc_brake_current(int16_t current)                   /* SCALE: 10          UNITS: Amps       */
+int8_t cascadiamc_set_max_dc_brake_current(int16_t current)                   /* SCALE: 10          UNITS: Amps       */
 {
     union
     {
@@ -378,9 +330,12 @@ void cascadiamc_set_max_dc_brake_current(int16_t current)                   /* S
     max_ac_brake_current_msg.id = msg_id;
 
     CAN_StatusTypedef status = can_send_message(max_ac_brake_current_msg);
+
+    if(status != HAL_OK){return 1;}
+    else {return 0;}
 }
 
-void cascadiamc_set_drive_enable(bool drive_enable)                         /* SCALE: 1           UNITS: No units   */
+int8_t cascadiamc_set_drive_enable(bool drive_enable)                         /* SCALE: 1           UNITS: No units   */
 {
     union
     {
@@ -404,4 +359,7 @@ void cascadiamc_set_drive_enable(bool drive_enable)                         /* S
     drive_enable_msg.id = msg_id;
 
     CAN_StatusTypedef status = can_send_message(drive_enable_msg);
+
+    if(status != HAL_OK){return 1;}
+    else {return 0;}
 }

--- a/Drivers/NER/src/cascadiamc.c
+++ b/Drivers/NER/src/cascadiamc.c
@@ -1,0 +1,407 @@
+/**
+ * @file cascadiamc.c
+ * @author Hamza Iqbal
+ * @brief Source file for Motor Controller Driver
+ * @version 0.1
+ * @date 2023-08-22
+ * 
+ * @copyright Copyright (c) 2023
+ * 
+ */
+
+#include "cascadiamc.h"
+
+void MC_init(mc_t* mc)
+{
+
+}
+
+void MC_update(mc_t* mc, can_msg_t message)
+{
+    switch(message.id)
+    {
+        case 0x2010:    // The byte furthest to the right is a standin for now, should be the last 2 digits of serial number in hex
+            int32_t ERPM = message.data >> 32;
+            mc->rpm = ERPM / NUM_POLES;
+            mc->duty_cycle = ((message.data >> 16) & 0x00000000FFFF);
+            mc->input_voltage = message.data & 0x00000000FFFF;
+        case 0x2110:    // The byte furthest to the right is a standin for now, should be the last 2 digits of serial number in hex
+            mc->ac_current = message.data >> 48;
+            mc->dc_current = ((message.data >> 32) & 0x00000000FFFF);
+        case 0x2210:    // The byte furthest to the right is a standin for now, should be the last 2 digits of serial number in hex
+            mc->cont_temp = message.data >> 48;
+            mc->motor_temp = ((message.data >> 32) & 0x00000000FFFF);
+            mc->fault_code = ((message.data >> 24) & 0x0000000000FF);
+        case 0x2310:    // The byte furthest to the right is a standin for now, should be the last 2 digits of serial number in hex
+            mc->throttle_signal = message.data >> 56;
+            mc->brake_signal = ((message.data >> 48) & 0x0000000000FF);
+            mc->drive_enable = ((message.data >> 39) & 0x000000000001);
+    }
+}
+
+int32_t MC_get_rpm(mc_t* mc)
+{
+    return mc->rpm;
+}
+
+int16_t MC_get_duty_cycle(mc_t* mc)
+{
+    return mc->duty_cycle;
+}
+
+int16_t MC_get_input_voltage(mc_t* mc)
+{
+    return mc->input_voltage;
+}
+
+int16_t MC_get_ac_current(mc_t* mc)
+{
+    return mc->ac_current;
+}
+
+int16_t MC_get_dc_current(mc_t* mc)
+{
+    return mc->dc_current;
+}
+
+int16_t MC_get_controller_temp(mc_t* mc)
+{
+    return mc->cont_temp;
+}
+
+int16_t MC_get_motor_temp(mc_t* mc)
+{
+    return mc->motor_temp;
+}
+
+uint8_t MC_get_fault_code(mc_t* mc)
+{
+    return mc->fault_code;
+}
+
+int8_t MC_get_throttle_signal(mc_t* mc)
+{
+    return mc->throttle_signal;
+}
+
+int8_t MC_get_brake_signal(mc_t* mc)
+{
+    return mc->brake_signal;
+}
+
+int8_t MC_get_drive_enable(mc_t* mc)
+{
+    return mc->drive_enable;
+}
+
+void MC_set_current(int16_t current)                                /* SCALE: 10          UNITS: Amps       */
+{
+    union
+    {
+        uint8_t msg[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+
+        struct
+        {
+            uint16_t ac_current;
+        } cfg;
+
+    } set_current_data;
+
+    uint32_t msg_id = 0x00000110;
+    uint8_t msg_len = 8;
+    uint8_t msg_line = 1;
+    set_current_data.cfg.ac_current = current;
+    can_msg_t current_msg;
+    current_msg.data = set_current_data.cfg;
+    current_msg.line = msg_line;
+    current_msg.len = msg_len;
+    current_msg.id = msg_id;
+    
+    CAN_StatusTypedef status = can_send_message(current_msg);
+}
+
+void MC_set_brake_current(int16_t brake_current)                    /* SCALE: 10          UNITS: Amps       */
+{
+    union
+    {
+        uint8_t msg[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+
+        struct
+        {
+            uint16_t brake_current;
+        } cfg;
+
+    } set_brake_current_data;
+
+    uint32_t msg_id = 0x00000210;
+    uint8_t msg_len = 8;
+    uint8_t msg_line = 1;
+    set_brake_current_data.cfg.brake_current = brake_current;
+    can_msg_t brake_current_msg;
+    brake_current_msg.data = set_brake_current_data.cfg;
+    brake_current_msg.line = msg_line;
+    brake_current_msg.len = msg_len;
+    brake_current_msg.id = msg_id;
+    
+    CAN_StatusTypedef status = can_send_message(brake_current_msg);
+}                                                  
+
+void MC_set_speed(int32_t rpm)                                      /* SCALE: 1           UNITS: RPM        */
+{
+    union
+    {
+        uint8_t msg[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+
+        struct
+        {
+            uint32_t erpm;
+        } cfg;
+
+    } set_speed_data;
+
+    uint32_t msg_id = 0x00000310;
+    uint8_t msg_len = 8;
+    uint8_t msg_line = 1;
+    set_speed_data.cfg.erpm = rpm * NUM_POLES;
+    can_msg_t speed_msg;
+    speed_msg.data = set_speed_data.cfg;
+    speed_msg.line = msg_line;
+    current_msg.len = msg_len;
+    current_msg.id = msg_id;
+    
+    CAN_StatusTypedef status = can_send_message(speed_msg);
+}                                     
+
+void MC_set_position(int16_t angle)                                 /* SCALE: 10          UNITS: Degrees    */
+{
+    union
+    {
+        uint8_t msg[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+
+        struct
+        {
+            uint16_t angle;
+        } cfg;
+
+    } set_position_data;
+
+    uint32_t msg_id = 0x00000410;
+    uint8_t msg_len = 8;
+    uint8_t msg_line = 1;
+    set_position_data.cfg.angle = angle;
+    can_msg_t position_msg;
+    position_msg.data = set_position_data.cfg;
+    position_msg.line = msg_line;
+    position_msg.len = msg_len;
+    position_msg.id = msg_id;
+    
+    CAN_StatusTypedef status = can_send_message(current_msg);
+}                                
+
+void MC_set_relative_current(int16_t relative_current)              /* SCALE: 10          UNITS: Percentage */
+{
+    union
+    {
+        uint8_t msg[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+
+        struct
+        {
+            uint16_t relative_current;
+        } cfg;
+
+    } set_relative_current_data;
+
+    uint32_t msg_id = 0x00000510;
+    uint8_t msg_len = 8;
+    uint8_t msg_line = 1;
+    set_relative_current_data.cfg.relative_current = relative_current;
+    can_msg_t relative_current_msg;
+    relative_current_msg.data = set_relative_current_data.cfg;
+    relative_current_msg.line = msg_line;
+    relative_current_msg.len = msg_len;
+    relative_current_msg.id = msg_id;
+    
+    CAN_StatusTypedef status = can_send_message(relative_current_msg);
+}             
+
+void MC_set_relative_brake_current(int16_t relative_brake_current)  /* SCALE: 10          UNITS: Percentage */
+{
+    union
+    {
+        uint8_t msg[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+
+        struct
+        {
+            uint16_t relative_brake_current;
+        } cfg;
+
+    } set_relative_brake_current_data;
+
+    uint32_t msg_id = 0x00000610;
+    uint8_t msg_len = 8;
+    uint8_t msg_line = 1;
+    set_relative_brake_current_data.cfg.relative_brake_current = relative_brake_current;
+    can_msg_t relative_brake_current_msg;
+    relative_brake_current_msg.data = set_relative_brake_current_data.cfg;
+    relative_brake_current_msg.line = msg_line;
+    relative_brake_current_msg.len = msg_len;
+    relative_brake_current_msg.id = msg_id;
+    
+    CAN_StatusTypedef status = can_send_message(relative_brake_current_msg);
+} 
+
+void MC_set_digital_output(uint8_t output, bool value)              /* SCALE: 1           UNITS: No units   */
+{
+    union
+    {
+        uint8_t msg[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+
+        struct
+        {
+            uint8_t digital_output;
+        } cfg;
+
+    } set_digital_output_data;
+
+    uint32_t msg_id = 0x00000710;
+    uint8_t msg_len = 8;
+    uint8_t msg_line = 1;
+    set_digital_output_data.cfg.digital_output = value >> output;
+    can_msg_t digital_output_msg;
+    digital_output_msg.data = set_digital_output_data.cfg;
+    digital_output_msg.line = msg_line;
+    digital_output_msg.len = msg_len;
+    digital_output_msg.id = msg_id;
+    
+    CAN_StatusTypedef status = can_send_message(digital_output_msg);
+}            
+
+void MC_set_max_ac_current(int16_t current)                         /* SCALE: 10          UNITS: Amps       */
+{
+    union
+    {
+        uint8_t msg[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+
+        struct
+        {
+            uint16_t max_current;
+        } cfg;
+
+    } set_max_ac_current_data;
+
+    uint32_t msg_id = 0x00000810;
+    uint8_t msg_len = 8;
+    uint8_t msg_line = 1;
+    set_max_ac_current_data.cfg.max_current = current;
+    can_msg_t max_ac_current_msg;
+    max_ac_current_msg.data = set_max_ac_current_data.cfg;
+    max_ac_current_msg.line = msg_line;
+    max_ac_current_msg.len = msg_len;
+    max_ac_current_msg.id = msg_id;
+    
+    CAN_StatusTypedef status = can_send_message(max_ac_current_msg);
+} 
+
+void MC_set_max_ac_brake_current(int16_t current)                   /* SCALE: 10          UNITS: Amps       */
+{
+    union
+    {
+        uint8_t msg[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+
+        struct
+        {
+            uint16_t max_brake_current;
+        } cfg;
+
+    } set_max_brake_ac_current_data;
+
+    uint32_t msg_id = 0x00000910;
+    uint8_t msg_len = 8;
+    uint8_t msg_line = 1;
+    set_max_ac_brake_current_data.cfg.max_brake_current = current;
+    can_msg_t max_ac_brake_current_msg;
+    max_ac_brake_current_msg.data = set_max_ac_current_data.cfg;
+    max_ac_brake_current_msg.line = msg_line;
+    max_ac_brake_current_msg.len = msg_len;
+    max_ac_brake_current_msg.id = msg_id;
+    
+    CAN_StatusTypedef status = can_send_message(max_ac_brake_current_msg);
+}                  
+
+void MC_set_max_dc_current(int16_t current)                         /* SCALE: 10          UNITS: Amps       */
+{
+    union
+    {
+        uint8_t msg[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+
+        struct
+        {
+            uint16_t max_current;
+        } cfg;
+
+    } set_max_dc_current_data;
+
+    uint32_t msg_id = 0x00000A10;
+    uint8_t msg_len = 8;
+    uint8_t msg_line = 1;
+    set_max_dc_current_data.cfg.max_current = current;
+    can_msg_t max_dc_current_msg;
+    max_dc_current_msg.data = set_max_dc_current_data.cfg;
+    max_dc_current_msg.line = msg_line;
+    max_dc_current_msg.len = msg_len;
+    max_dc_current_msg.id = msg_id;
+    
+    CAN_StatusTypedef status = can_send_message(max_dc_current_msg);
+}                        
+
+void MC_set_max_dc_brake_current(int16_t current)                   /* SCALE: 10          UNITS: Amps       */
+{
+    union
+    {
+        uint8_t msg[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+
+        struct
+        {
+            uint16_t max_brake_current;
+        } cfg;
+
+    } set_max_brake_ac_current_data;
+
+    uint32_t msg_id = 0x00000B10;
+    uint8_t msg_len = 8;
+    uint8_t msg_line = 1;
+    set_max_ac_brake_current_data.cfg.max_brake_current = current;
+    can_msg_t max_ac_brake_current_msg;
+    max_ac_brake_current_msg.data = set_max_ac_current_data.cfg;
+    max_ac_brake_current_msg.line = msg_line;
+    max_ac_brake_current_msg.len = msg_len;
+    max_ac_brake_current_msg.id = msg_id;
+    
+    CAN_StatusTypedef status = can_send_message(max_ac_brake_current_msg); 
+}                  
+
+void MC_set_drive_enable(bool drive_enable)                         /* SCALE: 1           UNITS: No units   */
+{
+    union
+    {
+        uint8_t msg[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+
+        struct
+        {
+            uint8_t drive_enable;
+        } cfg;
+
+    } set_drive_enable_data;
+
+    uint32_t msg_id = 0x00000C10;
+    uint8_t msg_len = 1;
+    uint8_t msg_line = 1;
+    set_drive_enable_data.cfg.drive_enable = drive_enable;
+    can_msg_t drive_enable_msg;
+    drive_enable_msg.data = set_max_ac_current_data.cfg;
+    drive_enable_msg.line = msg_line;
+    drive_enable_msg.len = msg_len;
+    drive_enable_msg.id = msg_id;
+    
+    CAN_StatusTypedef status = can_send_message(drive_enable_msg);
+}                        

--- a/Drivers/NER/src/cascadiamc.c
+++ b/Drivers/NER/src/cascadiamc.c
@@ -11,12 +11,12 @@
 
 #include "cascadiamc.h"
 
-void MC_init(mc_t* mc)
+void cascadiamc_init(cascadiamc_t* mc)
 {
 
 }
 
-void MC_update(mc_t* mc, can_msg_t message)
+void cascadiamc_update(cascadiamc_t* mc, can_msg_t message)
 {
     switch(message.id)
     {
@@ -39,62 +39,62 @@ void MC_update(mc_t* mc, can_msg_t message)
     }
 }
 
-int32_t MC_get_rpm(mc_t* mc)
+int32_t cascadiamc_get_rpm(cascadiamc_t* mc)
 {
     return mc->rpm;
 }
 
-int16_t MC_get_duty_cycle(mc_t* mc)
+int16_t cascadiamc_get_duty_cycle(cascadiamc_t* mc)
 {
     return mc->duty_cycle;
 }
 
-int16_t MC_get_input_voltage(mc_t* mc)
+int16_t cascadiamc_get_input_voltage(cascadiamc_t* mc)
 {
     return mc->input_voltage;
 }
 
-int16_t MC_get_ac_current(mc_t* mc)
+int16_t cascadiamc_get_ac_current(cascadiamc_t* mc)
 {
     return mc->ac_current;
 }
 
-int16_t MC_get_dc_current(mc_t* mc)
+int16_t cascadiamc_get_dc_current(cascadiamc_t* mc)
 {
     return mc->dc_current;
 }
 
-int16_t MC_get_controller_temp(mc_t* mc)
+int16_t cascadiamc_get_controller_temp(cascadiamc_t* mc)
 {
     return mc->cont_temp;
 }
 
-int16_t MC_get_motor_temp(mc_t* mc)
+int16_t cascadiamc_get_motor_temp(cascadiamc_t* mc)
 {
     return mc->motor_temp;
 }
 
-uint8_t MC_get_fault_code(mc_t* mc)
+uint8_t cascadiamc_get_fault_code(cascadiamc_t* mc)
 {
     return mc->fault_code;
 }
 
-int8_t MC_get_throttle_signal(mc_t* mc)
+int8_t cascadiamc_get_throttle_signal(cascadiamc_t* mc)
 {
     return mc->throttle_signal;
 }
 
-int8_t MC_get_brake_signal(mc_t* mc)
+int8_t cascadiamc_get_brake_signal(cascadiamc_t* mc)
 {
     return mc->brake_signal;
 }
 
-int8_t MC_get_drive_enable(mc_t* mc)
+int8_t cascadiamc_get_drive_enable(cascadiamc_t* mc)
 {
     return mc->drive_enable;
 }
 
-void MC_set_current(int16_t current)                                /* SCALE: 10          UNITS: Amps       */
+void cascadiamc_set_current(int16_t current)                                /* SCALE: 10          UNITS: Amps       */
 {
     union
     {
@@ -120,7 +120,7 @@ void MC_set_current(int16_t current)                                /* SCALE: 10
     CAN_StatusTypedef status = can_send_message(current_msg);
 }
 
-void MC_set_brake_current(int16_t brake_current)                    /* SCALE: 10          UNITS: Amps       */
+void cascadiamc_set_brake_current(int16_t brake_current)                    /* SCALE: 10          UNITS: Amps       */
 {
     union
     {
@@ -146,7 +146,7 @@ void MC_set_brake_current(int16_t brake_current)                    /* SCALE: 10
     CAN_StatusTypedef status = can_send_message(brake_current_msg);
 }                                                  
 
-void MC_set_speed(int32_t rpm)                                      /* SCALE: 1           UNITS: RPM        */
+void cascadiamc_set_speed(int32_t rpm)                                      /* SCALE: 1           UNITS: RPM        */
 {
     union
     {
@@ -172,7 +172,7 @@ void MC_set_speed(int32_t rpm)                                      /* SCALE: 1 
     CAN_StatusTypedef status = can_send_message(speed_msg);
 }                                     
 
-void MC_set_position(int16_t angle)                                 /* SCALE: 10          UNITS: Degrees    */
+void cascadiamc_set_position(int16_t angle)                                 /* SCALE: 10          UNITS: Degrees    */
 {
     union
     {
@@ -198,7 +198,7 @@ void MC_set_position(int16_t angle)                                 /* SCALE: 10
     CAN_StatusTypedef status = can_send_message(current_msg);
 }                                
 
-void MC_set_relative_current(int16_t relative_current)              /* SCALE: 10          UNITS: Percentage */
+void cascadiamc_set_relative_current(int16_t relative_current)              /* SCALE: 10          UNITS: Percentage */
 {
     union
     {
@@ -224,7 +224,7 @@ void MC_set_relative_current(int16_t relative_current)              /* SCALE: 10
     CAN_StatusTypedef status = can_send_message(relative_current_msg);
 }             
 
-void MC_set_relative_brake_current(int16_t relative_brake_current)  /* SCALE: 10          UNITS: Percentage */
+void cascadiamc_set_relative_brake_current(int16_t relative_brake_current)  /* SCALE: 10          UNITS: Percentage */
 {
     union
     {
@@ -250,7 +250,7 @@ void MC_set_relative_brake_current(int16_t relative_brake_current)  /* SCALE: 10
     CAN_StatusTypedef status = can_send_message(relative_brake_current_msg);
 } 
 
-void MC_set_digital_output(uint8_t output, bool value)              /* SCALE: 1           UNITS: No units   */
+void cascadiamc_set_digital_output(uint8_t output, bool value)              /* SCALE: 1           UNITS: No units   */
 {
     union
     {
@@ -276,7 +276,7 @@ void MC_set_digital_output(uint8_t output, bool value)              /* SCALE: 1 
     CAN_StatusTypedef status = can_send_message(digital_output_msg);
 }            
 
-void MC_set_max_ac_current(int16_t current)                         /* SCALE: 10          UNITS: Amps       */
+void cascadiamc_set_max_ac_current(int16_t current)                         /* SCALE: 10          UNITS: Amps       */
 {
     union
     {
@@ -302,7 +302,7 @@ void MC_set_max_ac_current(int16_t current)                         /* SCALE: 10
     CAN_StatusTypedef status = can_send_message(max_ac_current_msg);
 } 
 
-void MC_set_max_ac_brake_current(int16_t current)                   /* SCALE: 10          UNITS: Amps       */
+void cascadiamc_set_max_ac_brake_current(int16_t current)                   /* SCALE: 10          UNITS: Amps       */
 {
     union
     {
@@ -328,7 +328,7 @@ void MC_set_max_ac_brake_current(int16_t current)                   /* SCALE: 10
     CAN_StatusTypedef status = can_send_message(max_ac_brake_current_msg);
 }                  
 
-void MC_set_max_dc_current(int16_t current)                         /* SCALE: 10          UNITS: Amps       */
+void cascadiamc_set_max_dc_current(int16_t current)                         /* SCALE: 10          UNITS: Amps       */
 {
     union
     {
@@ -354,7 +354,7 @@ void MC_set_max_dc_current(int16_t current)                         /* SCALE: 10
     CAN_StatusTypedef status = can_send_message(max_dc_current_msg);
 }                        
 
-void MC_set_max_dc_brake_current(int16_t current)                   /* SCALE: 10          UNITS: Amps       */
+void cascadiamc_set_max_dc_brake_current(int16_t current)                   /* SCALE: 10          UNITS: Amps       */
 {
     union
     {
@@ -380,7 +380,7 @@ void MC_set_max_dc_brake_current(int16_t current)                   /* SCALE: 10
     CAN_StatusTypedef status = can_send_message(max_ac_brake_current_msg); 
 }                  
 
-void MC_set_drive_enable(bool drive_enable)                         /* SCALE: 1           UNITS: No units   */
+void cascadiamc_set_drive_enable(bool drive_enable)                         /* SCALE: 1           UNITS: No units   */
 {
     union
     {

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_spi.c \
 Drivers/NER/src/lsm6dso.c \
 Drivers/NER/src/sht30.c \
 Drivers/NER/src/can.c \
+Drivers/NER/src/cascadiamc.c \
 Core/Src/system_stm32f4xx.c \
 Middlewares/Third_Party/FreeRTOS/Source/croutine.c \
 Middlewares/Third_Party/FreeRTOS/Source/event_groups.c \


### PR DESCRIPTION
Making a PR for @HamzaIqbal69, this is a basic driver for the Cascadia motor Controller we are using for 22A. This provides a get/set interface for abstracting writing parameters over CAN and also implements a callback functionality to route CAN data to the correct fields of a local struct used during initialization