### PR TITLE
51 temp monitor

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "Drivers/Embedded-Base"]
 	path = Drivers/Embedded-Base
 	url = git@github.com:Northeastern-Electric-Racing/Embedded-Base.git
+	branch = main

--- a/Core/Inc/cerberus_conf.h
+++ b/Core/Inc/cerberus_conf.h
@@ -1,0 +1,1 @@
+#define CANID_TEMP_SENSOR 0xBEEF

--- a/Core/Inc/fault.h
+++ b/Core/Inc/fault.h
@@ -1,0 +1,36 @@
+#ifndef CERBERUS_FAULT_H
+#define CERBERUS_FAULT_H
+
+#include "cmsis_os.h"
+#include "cerberus_conf.h"
+
+#define FAULT_HANDLE_QUEUE_SIZE 16
+
+typedef enum {
+    DEFCON1 = 1,
+    DEFCON2,
+    DEFCON3,
+    DEFCON4,
+    DEFCON5
+} fault_sev_t;
+
+typedef enum {
+    FAULTS_CLEAR        = 0x0,
+    ONBOARD_TEMP_FAULT  = 0x1
+} fault_code_t;
+
+//TODO: Make this queue not accessible to users,
+//  Make this into a wrapped function for "trigger_fault"
+//  and then expose _that_ to the user
+typedef struct {
+    fault_code_t id;
+    fault_sev_t severity;
+    char *diag;
+} fault_data_t;
+
+//TODO: Make this queue not accessible to users,
+//  Make this into a wrapped function for "trigger_fault"
+//  and then expose _that_ to the user
+extern osMessageQueueId_t fault_handle_queue;
+
+#endif // FAULT_H

--- a/Core/Inc/monitor.h
+++ b/Core/Inc/monitor.h
@@ -1,0 +1,16 @@
+#ifndef MONITOR_H
+#define MONITOR_H
+
+#include "cmsis_os.h"
+
+/* Defining Temperature Monitor Task */
+void vTempMonitor(void *pv_params);
+
+osThreadId_t temp_monitor_handle;
+const osThreadAttr_t temp_monitor_attributes = {
+  .name = "TempMonitor",
+  .stack_size = 128 * 4,
+  .priority = (osPriority_t) osPriorityBelowNormal3,
+};
+
+#endif // MONITOR_H

--- a/Core/Inc/monitor.h
+++ b/Core/Inc/monitor.h
@@ -8,9 +8,9 @@ void vTempMonitor(void *pv_params);
 
 osThreadId_t temp_monitor_handle;
 const osThreadAttr_t temp_monitor_attributes = {
-  .name = "TempMonitor",
-  .stack_size = 128 * 4,
-  .priority = (osPriority_t) osPriorityBelowNormal3,
+	.name = "TempMonitor",
+	.stack_size = 128 * 4,
+	.priority = (osPriority_t) osPriorityBelowNormal3,
 };
 
 #endif // MONITOR_H

--- a/Core/Inc/monitor.h
+++ b/Core/Inc/monitor.h
@@ -6,11 +6,7 @@
 /* Defining Temperature Monitor Task */
 void vTempMonitor(void *pv_params);
 
-osThreadId_t temp_monitor_handle;
-const osThreadAttr_t temp_monitor_attributes = {
-	.name = "TempMonitor",
-	.stack_size = 128 * 4,
-	.priority = (osPriority_t) osPriorityBelowNormal3,
-};
+extern osThreadId_t temp_monitor_handle;
+extern const osThreadAttr_t temp_monitor_attributes;
 
 #endif // MONITOR_H

--- a/Core/Inc/monitor.h
+++ b/Core/Inc/monitor.h
@@ -1,5 +1,5 @@
-#ifndef MONITOR_H
-#define MONITOR_H
+#ifndef CERBERUS_MONITOR_H
+#define CERBERUS_MONITOR_H
 
 #include "cmsis_os.h"
 

--- a/Core/Inc/queues.h
+++ b/Core/Inc/queues.h
@@ -1,10 +1,11 @@
-#ifndef QUEUES_H
-#define QUEUES_H
+#ifndef CERBERUS_QUEUES_H
+#define CERBERUS_QUEUES_H
 
 #include "cmsis_os.h"
+#include "cerberus_conf.h"
 
 
-#define NUM_ONBOARD_TEMP_QUEUE  8
+#define ONBOARD_TEMP_QUEUE_SIZE  8
 
 typedef struct {
     uint16_t temperature;
@@ -12,5 +13,6 @@ typedef struct {
 } onboard_temp_t;
 
 extern osMessageQueueId_t onboard_temp_queue;
+
 
 #endif // QUEUES_H

--- a/Core/Inc/queues.h
+++ b/Core/Inc/queues.h
@@ -1,0 +1,16 @@
+#ifndef QUEUES_H
+#define QUEUES_H
+
+#include "cmsis_os.h"
+
+
+#define NUM_ONBOARD_TEMP_QUEUE  8
+
+typedef struct {
+    uint16_t temperature;
+    uint16_t humidity;
+} onboard_temp_t;
+
+extern osMessageQueueId_t onboard_temp_queue;
+
+#endif // QUEUES_H

--- a/Core/Src/fault.c
+++ b/Core/Src/fault.c
@@ -1,0 +1,3 @@
+#include "fault.h"
+
+osMessageQueueId_t fault_handle_queue;

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -142,7 +142,7 @@ int main(void)
   defaultTaskHandle = osThreadNew(StartDefaultTask, NULL, &defaultTask_attributes);
 
   /* USER CODE BEGIN RTOS_THREADS */
-  temp_monitor_handle = osThreadNew(vTempMonitor, NULL, &temp_monitor_attributes);
+  temp_monitor_handle = osThreadNew(vTempMonitor, &hi2c1, &temp_monitor_attributes);
   /* USER CODE END RTOS_THREADS */
 
   /* USER CODE BEGIN RTOS_EVENTS */

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -21,6 +21,7 @@
 #include "cmsis_os.h"
 #include "sht30.h"
 #include "monitor.h"
+#include "queues.h"
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
@@ -59,7 +60,7 @@ const osThreadAttr_t defaultTask_attributes = {
   .priority = (osPriority_t) osPriorityNormal,
 };
 /* USER CODE BEGIN PV */
-
+osMessageQueueId_t onboard_temp_queue;
 /* USER CODE END PV */
 
 /* Private function prototypes -----------------------------------------------*/
@@ -134,7 +135,7 @@ int main(void)
   /* USER CODE END RTOS_TIMERS */
 
   /* USER CODE BEGIN RTOS_QUEUES */
-  /* add queues, ... */
+  onboard_temp_queue = osMessageQueueNew(NUM_ONBOARD_TEMP_QUEUE, sizeof(onboard_temp_t), NULL);
   /* USER CODE END RTOS_QUEUES */
 
   /* Create the thread(s) */

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -50,8 +50,6 @@ I2C_HandleTypeDef hi2c2;
 SPI_HandleTypeDef hspi1;
 SPI_HandleTypeDef hspi2;
 
-sht30_t temp_sensor;
-
 /* Definitions for defaultTask */
 osThreadId_t defaultTaskHandle;
 const osThreadAttr_t defaultTask_attributes = {
@@ -116,9 +114,6 @@ int main(void)
   MX_SPI1_Init();
   MX_SPI2_Init();
   /* USER CODE BEGIN 2 */
-
-  //if(sht30_init(&temp_sensor, &hi2c1))
-    //Error_Handler();
 
   /* USER CODE END 2 */
 

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -22,6 +22,7 @@
 #include "sht30.h"
 #include "monitor.h"
 #include "queues.h"
+#include "fault.h"
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
@@ -135,7 +136,8 @@ int main(void)
   /* USER CODE END RTOS_TIMERS */
 
   /* USER CODE BEGIN RTOS_QUEUES */
-  onboard_temp_queue = osMessageQueueNew(NUM_ONBOARD_TEMP_QUEUE, sizeof(onboard_temp_t), NULL);
+  onboard_temp_queue = osMessageQueueNew(ONBOARD_TEMP_QUEUE_SIZE, sizeof(onboard_temp_t), NULL);
+  fault_handle_queue = osMessageQueueNew(FAULT_HANDLE_QUEUE_SIZE, sizeof(fault_data_t), NULL);
   /* USER CODE END RTOS_QUEUES */
 
   /* Create the thread(s) */

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -20,6 +20,7 @@
 #include "main.h"
 #include "cmsis_os.h"
 #include "sht30.h"
+#include "monitor.h"
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
@@ -141,7 +142,7 @@ int main(void)
   defaultTaskHandle = osThreadNew(StartDefaultTask, NULL, &defaultTask_attributes);
 
   /* USER CODE BEGIN RTOS_THREADS */
-  /* add threads, ... */
+  temp_monitor_handle = osThreadNew(vTempMonitor, NULL, &temp_monitor_attributes);
   /* USER CODE END RTOS_THREADS */
 
   /* USER CODE BEGIN RTOS_EVENTS */

--- a/Core/Src/monitor.c
+++ b/Core/Src/monitor.c
@@ -51,6 +51,6 @@ void vTempMonitor(void *pv_params)
 		}
 
 		/* Yield to other tasks */
-		osDelayUntil();
+		osDelayUntil(temp_sensor_sample_delay);
 	}
 }

--- a/Core/Src/monitor.c
+++ b/Core/Src/monitor.c
@@ -17,7 +17,7 @@ const osThreadAttr_t temp_monitor_attributes = {
 void vTempMonitor(void *pv_params)
 {
 	const uint8_t num_samples = 10;
-	const uint8_t temp_sensor_sample_delay = 500; /* ms */
+	const uint16_t temp_sensor_sample_delay = 500; /* ms */
 	const uint8_t can_msg_len = 4; /* bytes */
 	static onboard_temp_t sensor_data;
 	fault_data_t fault_data = {
@@ -34,8 +34,9 @@ void vTempMonitor(void *pv_params)
 	};
 
 	hi2c1 = (I2C_HandleTypeDef *)pv_params;
+	temp_sensor.i2c_handle = hi2c1;
 
-	if (sht30_init(&temp_sensor, &hi2c1)) {
+	if (sht30_init(&temp_sensor)) {
 		fault_data.diag = "Init Failed";
 		osMessageQueuePut(fault_handle_queue, &fault_data , 0U, 0U);
 	}

--- a/Core/Src/monitor.c
+++ b/Core/Src/monitor.c
@@ -1,0 +1,52 @@
+#include <sht30.h>
+#include <FreeRTOS.h>
+#include "cerberus_conf.h"
+#include "task.h"
+#include "can.h"
+
+void vTempMonitor(void *pv_params)
+{
+    static const uint8_t num_samples = 10;
+
+    sht30_t temp_sensor;
+    I2C_HandleTypeDef *hi2c1;
+    can_msg_t temp_msg = {
+        .id = CANID_TEMP_SENSOR,
+        .len = 4, /* bytes */
+        .line = CAN_LINE_1
+    };
+    struct {
+        uint16_t temperature;
+        uint16_t humidity;
+    } sensor_data;
+    
+
+    hi2c1 = (I2C_HandleTypeDef *)pv_params;
+
+    if (sht30_init(&temp_sensor, &hi2c1)) {
+        //TODO: Handle error
+    }
+
+    for(;;) {
+
+        /* Take measurement */
+        if (sht30_get_temp_humid(&temp_sensor)) {
+            //TODO: Handler error
+        }
+
+        /* Run values through LPF of sample size  */
+        sensor_data.temperature = (sensor_data.temperature + temp_sensor.temp) 
+                                  / num_samples;
+        sensor_data.humidity = (sensor_data.humidity + temp_sensor.humidity) 
+                               / num_samples;
+
+        /* Send CAN message */
+        temp_msg.data = (uint8_t *) sensor_data;
+        if (can_send_message(temp_msg)) {
+            //TODO: Handle error
+        }
+
+        /* Yield to other tasks */
+        taskYIELD();
+    }
+}

--- a/Core/Src/monitor.c
+++ b/Core/Src/monitor.c
@@ -1,52 +1,56 @@
 #include <sht30.h>
 #include <FreeRTOS.h>
+#include <string.h>
 #include "cerberus_conf.h"
 #include "task.h"
 #include "can.h"
 
 void vTempMonitor(void *pv_params)
 {
-    static const uint8_t num_samples = 10;
+	static const uint8_t num_samples = 10;
+	static const uint8_t temp_sensor_sample_delay = 500; /* ms */
+	static const uint8_t can_msg_len = 4; /* bytes */
 
-    sht30_t temp_sensor;
-    I2C_HandleTypeDef *hi2c1;
-    can_msg_t temp_msg = {
-        .id = CANID_TEMP_SENSOR,
-        .len = 4, /* bytes */
-        .line = CAN_LINE_1
-    };
-    struct {
-        uint16_t temperature;
-        uint16_t humidity;
-    } sensor_data;
-    
+	sht30_t temp_sensor;
+	I2C_HandleTypeDef *hi2c1;
+	can_msg_t temp_msg = {
+		.id = CANID_TEMP_SENSOR,
+		.len = can_msg_len,
+		.line = CAN_LINE_1,
+		.data = {0}
+	};
 
-    hi2c1 = (I2C_HandleTypeDef *)pv_params;
+	struct {
+		uint16_t temperature;
+		uint16_t humidity;
+	} sensor_data;
 
-    if (sht30_init(&temp_sensor, &hi2c1)) {
-        //TODO: Handle error
-    }
+	hi2c1 = (I2C_HandleTypeDef *)pv_params;
 
-    for(;;) {
+	if (sht30_init(&temp_sensor, &hi2c1)) {
+		//TODO: Handle error
+	}
 
-        /* Take measurement */
-        if (sht30_get_temp_humid(&temp_sensor)) {
-            //TODO: Handler error
-        }
+	for(;;) {
 
-        /* Run values through LPF of sample size  */
-        sensor_data.temperature = (sensor_data.temperature + temp_sensor.temp) 
-                                  / num_samples;
-        sensor_data.humidity = (sensor_data.humidity + temp_sensor.humidity) 
-                               / num_samples;
+		/* Take measurement */
+		if (sht30_get_temp_humid(&temp_sensor)) {
+			//TODO: Handler error
+		}
 
-        /* Send CAN message */
-        temp_msg.data = (uint8_t *) sensor_data;
-        if (can_send_message(temp_msg)) {
-            //TODO: Handle error
-        }
+		/* Run values through LPF of sample size  */
+		sensor_data.temperature = (sensor_data.temperature + temp_sensor.temp)
+								  / num_samples;
+		sensor_data.humidity = (sensor_data.humidity + temp_sensor.humidity)
+							   / num_samples;
 
-        /* Yield to other tasks */
-        taskYIELD();
-    }
+		/* Send CAN message */
+		memcpy(temp_msg.data, &sensor_data, can_msg_len);
+		if (can_send_message(temp_msg)) {
+			//TODO: Handle error
+		}
+
+		/* Yield to other tasks */
+		osDelayUntil();
+	}
 }

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ Core/Src/freertos.c \
 Core/Src/stm32f4xx_it.c \
 Core/Src/stm32f4xx_hal_msp.c \
 Core/Src/monitor.c \
+Core/Src/fault.c \
 Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_can.c \
 Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_rcc.c \
 Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_rcc_ex.c \

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,8 @@ C_INCLUDES =  \
 -ICore/Inc \
 -IDrivers/STM32F4xx_HAL_Driver/Inc \
 -IDrivers/STM32F4xx_HAL_Driver/Inc/Legacy \
--IDrivers/Embedded-Base/stm32f405/inc \
+-IDrivers/Embedded-Base/platforms/stm32f405/include \
+-IDrivers/Embedded-Base/general/include \
 -IMiddlewares/Third_Party/FreeRTOS/Source/include \
 -IMiddlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2 \
 -IMiddlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM4F \

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ Core/Src/main.c \
 Core/Src/freertos.c \
 Core/Src/stm32f4xx_it.c \
 Core/Src/stm32f4xx_hal_msp.c \
+Core/Src/monitor.c \
 Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_can.c \
 Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_rcc.c \
 Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_rcc_ex.c \

--- a/Makefile
+++ b/Makefile
@@ -66,10 +66,10 @@ Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_tim_ex.c \
 Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_i2c.c \
 Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_i2c_ex.c \
 Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_spi.c \
-Drivers/Embedded-Base/stm32f405/src/lsm6dso.c \
-Drivers/Embedded-Base/stm32f405/src/sht30.c \
-Drivers/Embedded-Base/stm32f405/src/can.c \
-Drivers/Embedded-Base/stm32f405/src/pi4ioe.c \
+Drivers/Embedded-Base/general/src/lsm6dso.c \
+Drivers/Embedded-Base/general/src/sht30.c \
+Drivers/Embedded-Base/platforms/stm32f405/src/can.c \
+Drivers/Embedded-Base/general/src/pi4ioe.c \
 Core/Src/system_stm32f4xx.c \
 Middlewares/Third_Party/FreeRTOS/Source/croutine.c \
 Middlewares/Third_Party/FreeRTOS/Source/event_groups.c \


### PR DESCRIPTION
Here is a super quick implementation of a really really basic temperature monitor for #51. This goes through an example of defining an RTOS task, what it might look like, etc. There is a lot missing but I hope it helps demonstrate the general gist of what we should be doing.

Not currently tested but working on improving this in the coming days. TLDR I need to:
* ~Figure out error handling~
* ~Actually pass the I2C bus~
* ~Adjust the LPF on the data (do we even need one? Is it already done in hardware?)~
* ~Figure out best method of making this data available to other processes~
* Mutexing the I2C bus
* Implementing a CAN wrapper to push to a central CAN dispatch queue (another ticket)
* ~Make this actually build lol~