### PR TITLE
Docker imprv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,10 @@ echo 'if [ $n -e /home/app/cerberus.ioc ]; then echo \
 /    \  \/_/ __ \_  __ \ __ \_/ __ \_  __ \  |  \/  ___/\n\
 \     \___\  ___/|  | \/ \_\ \  ___/|  | \/  |  /\___ \ \n\
  \______  /\___  >__|  |___  /\___  >__|  |____//____  >\n\
-        \/     \/          \/     \/                 \/ "; fi;' >> ~/.bashrc && \
-echo 'alias open_serial="minicom -b 115200 -o -D /dev/ttyACM0"' >> ~/.bashrc && \
-echo 'alias flash_stm="openocd -f interface/cmsis-dap.cfg -f target/stm32f4x.cfg -c \"adapter speed 5000\" -c \"program ./build/cerberus.elf verify reset exit\""' >> ~/.bashrc
+        \/     \/          \/     \/                 \/ "; fi;' >> ~/.bashrc \
+&& echo 'alias serial="minicom -b 115200 -o -D /dev/ttyACM0"' >> ~/.bashrc \
+&& echo 'alias flash="openocd -f interface/cmsis-dap.cfg -f target/stm32f4x.cfg -c \"adapter speed 5000\" -c \"program /home/app/build/cerberus.elf verify reset exit\""' >> ~/.bashrc \
+&& echo 'alias emulate="renode /home/app/*.resc"'
 
 # Install cross compiler
 RUN wget -qO- https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2 | tar -xvj

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV PATH $PATH:/renode_portable
 WORKDIR /home/dev
 ADD . /home/dev
 
-RUN echo 'if [ $n -e /home/app/shepherd.ioc ]; then echo \
+RUN echo 'if [ $n -e /home/app/shepherd2.ioc ]; then echo \
 " ______     __  __     ______     ______   __  __     ______     ______     _____\n\
 /\  ___\   /\ \_\ \   /\  ___\   /\  == \ /\ \_\ \   /\  ___\   /\  == \   /\  __-.\n\
 \ \___  \  \ \  __ \  \ \  __\   \ \  _-/ \ \  __ \  \ \  __\   \ \  __<   \ \ \/\ \ \n\
@@ -39,7 +39,7 @@ echo 'if [ $n -e /home/app/cerberus.ioc ]; then echo \
         \/     \/          \/     \/                 \/ "; fi;' >> ~/.bashrc \
 && echo 'alias serial="minicom -b 115200 -o -D /dev/ttyACM0"' >> ~/.bashrc \
 && echo 'alias flash="openocd -f interface/cmsis-dap.cfg -f target/stm32f4x.cfg -c \"adapter speed 5000\" -c \"program /home/app/build/cerberus.elf verify reset exit\""' >> ~/.bashrc \
-&& echo 'alias emulate="renode /home/app/*.resc"'
+&& echo 'alias emulate="renode /home/app/*.resc"' >> ~/.bashrc
 
 # Install cross compiler
 RUN wget -qO- https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2 | tar -xvj

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ sudo docker run --rm -it --privileged -v "$PWD:/home/app" nwdepatie/ner-gcc-arm:
 ```
 
 ## Container Tools and Utilities
-> This container is packed with tools that can be utilized by developers to give them more insight into their developed software
+> This container is packed with tools that can be utilized by developers to give them more insight into their developed software, we've used bash aliases to make the commands more compact for ease of use
 ```
 ## Tools / Utils
 
@@ -31,15 +31,20 @@ sudo docker run --rm -it --privileged -v "$PWD:/home/app" nwdepatie/ner-gcc-arm:
 make all
 
 # to run Renode emulation
-renode
-i @cerberus.resc
+emulate
 start
+# Actual command is:
+# renode cerberus.resc
 
 # to open a serial port with Rasberry Pi Probe (make sure /dev/tty0/ACM0 exists first)
-minicom -b 115200 -o -D /dev/ttyACM0
+serial
+# Actual command is:
+# minicom -b 115200 -o -D /dev/ttyACM0
 
 # to flash STM board with Raspberry Pi Probe (WIP)
-openocd -f interface/cmsis-dap.cfg -f target/stm32f4x.cfg -c "adapter speed 5000" -c "program ./build/cerberus.elf verify reset exit"
+flash
+# Actual command is:
+# openocd -f interface/cmsis-dap.cfg -f target/stm32f4x.cfg -c "adapter speed 5000" -c "program ./build/cerberus.elf verify reset exit"
 ```
 ### Mounting Hardware to Docker Container in Windows
 > Very specific use case but nonetheless needed, also documented in the above confluence page, on macOS and Linux this happens by default when running privileged docker container

--- a/cerberus.resc
+++ b/cerberus.resc
@@ -4,7 +4,7 @@
 using sysbus
 
 mach create
-machine LoadPlatformDescription @test/renode/stm32f405.repl
+machine LoadPlatformDescription @Test/renode/stm32f405.repl
 sysbus.cpu LogFunctionNames true
 sysbus LogAllPeripheralsAccess true
 


### PR DESCRIPTION
This is more of a general PR for some docker cleaning up I did:
* Shortened the bash aliases for flashing, opening a serial port, and emulation startup
* Changed directory path within cerberus.resc so that there are no errors generated
* Modifying README with documentation