### PR TITLE
Unit testing framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,13 @@ Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM4F/port.c
 ASM_SOURCES =  \
 startup_stm32f405xx.s
 
+# Test source files
+TEST_SOURCE_FILES = \
+Test/unity/tests/cerberus_test.c \
+Test/unity/tests/can_handler_test.c
+# Unity source files and includes
+UNITY_DIR = Test/unity/src
+UNITY_SOURCES = $(UNITY_DIR)/unity.c
 
 #######################################
 # binaries
@@ -149,6 +156,19 @@ C_INCLUDES =  \
 -IDrivers/CMSIS/Device/ST/STM32F4xx/Include \
 -IDrivers/CMSIS/Include
 
+# test includes
+UNITY_INCLUDES = \
+-I$(UNITY_DIR) \
+-ITest/unity/tests \
+-ICore/Src \
+-ICore/Inc \
+-IDrivers/Embedded-Base/platforms/stm32f405/include \
+-IDrivers/Embedded-Base/general/include \
+-IDrivers/Embedded-Base/middleware/include \
+-IMiddlewares/Third_Party/FreeRTOS/Source/include \
+-IMiddlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2 \
+-IMiddlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM4F
+
 # compile gcc flags
 ASFLAGS = $(MCU) $(AS_DEFS) $(AS_INCLUDES) $(OPT) -Wall -fdata-sections -ffunction-sections
 
@@ -206,6 +226,15 @@ $(BUILD_DIR)/%.bin: $(BUILD_DIR)/%.elf | $(BUILD_DIR)
 	
 $(BUILD_DIR):
 	mkdir $@		
+
+#######################################
+# run unit tests
+#######################################
+test: $(BUILD_DIR)/test_$(TARGET)
+	./$(BUILD_DIR)/test_$(TARGET)
+$(BUILD_DIR)/test_$(TARGET): $(TEST_SOURCE_FILES) $(UNITY_SOURCES) | $(BUILD_DIR)
+	gcc -D UNIT_TEST $(UNITY_INCLUDES) -o $@ $^
+#######################################
 
 #######################################
 # clean up

--- a/Test/unity/tests/can_handler_test.c
+++ b/Test/unity/tests/can_handler_test.c
@@ -1,0 +1,6 @@
+#include "unity.h"
+
+void test_can_handler(void)
+{
+    //TEST_ASSERT_NOT_NULL(getFunction(0x2010));
+}

--- a/Test/unity/tests/cerberus_test.c
+++ b/Test/unity/tests/cerberus_test.c
@@ -1,0 +1,16 @@
+#include "unity.h"
+#include "cerberus_test.h"
+
+void setUp(void) {
+    // set stuff up here
+}
+
+void tearDown(void) {
+    // clean stuff up here
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_can_handler);
+    return UNITY_END();
+}

--- a/Test/unity/tests/cerberus_test.h
+++ b/Test/unity/tests/cerberus_test.h
@@ -1,0 +1,17 @@
+#ifndef CERBERUS_TEST_H
+#define CERBERUS_TEST_H
+
+/* 
+ *  ************** NOTE **************
+ *  These test files are specifically 
+ *  for unit tests, developers can 
+ *  make sure that specific functions 
+ *  and APIs meet requirements set out. 
+ *  This should NOT be used for actually 
+ *  simulating drivers and hardware, 
+ *  that is what we are using Renode for
+ */
+
+void test_can_handler(void);
+
+#endif // CERBERUS_TEST_H


### PR DESCRIPTION
This PR is adding in Unity, a lightweight unit test framework for C, into our codebase. This should allow developers to easily unit test specific pieces of their code for edge cases. This will also be fairly useful for creating and tuning algorithms. This is in addition to Renode, where Renode will be used to test code on virtual hardware. I think the goal is to build these all into a single test pipeline that developers can just run that will run:
1. Simple Unity tests
2. Renode emulation on platform alone
3. Renode integration test for compatibility between codebases


Hopefully this will ensure that the code that we deploy to the car is fairly robust, already. We can then integrate them into CI for GitHub Actions to have an incredibly robust testing pipeline

NOTE:
This does not fully work yet, we need to figure out the best way of mocking drivers. It might boil down to just mocking a bunch of data types which would be gross but would work. Driver mocks might be useful to put into `Embedded-Base` if we go down that route


To actually run the tests, you run `make test` in the docker container and it will run through a bunch of tests for you by automatically running the compiled testing binary