### PR TITLE
Copying the finalized clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,18 @@
-style: llvm
+﻿---
+BasedOnStyle: WebKit
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: 'true'
+AlignConsecutiveAssignments: 'true'
+AlignOperands: 'true'
+AlignTrailingComments: 'true'
+AllowShortBlocksOnASingleLine: 'false'
+AllowShortFunctionsOnASingleLine: InlineOnly
+AllowShortLoopsOnASingleLine: 'false'
+ColumnLimit: '100'
+IndentWidth: '4'
+SpaceAfterLogicalNot: 'false'
+SpaceBeforeAssignmentOperators: 'true'
+SpaceBeforeRangeBasedForLoopColon: 'true'
+TabWidth: '4'
+UseTab: Always
+---


### PR DESCRIPTION
This is just making a better clang-format. We utilized an online clang format renderer to create a format we really liked and tested it out on shepherd, which I was a fan of. Only funky thing is that when running it in docker it modifies the permissions of the local file so that people cant save on Linux :grimacing: . Otherwise it do work tho