### PR TITLE
Adding in function to queue a fault to be handled

### DIFF
--- a/Core/Inc/can_handler.h
+++ b/Core/Inc/can_handler.h
@@ -25,6 +25,6 @@ void vCanDispatch(void* pv_params);
 extern osThreadId_t can_dispatch_handle;
 extern const osThreadAttr_t can_dispatch_attributes;
 
-void queue_can_msg(can_msg_t msg);
+int queue_can_msg(can_msg_t msg);
 
 #endif

--- a/Core/Inc/fault.h
+++ b/Core/Inc/fault.h
@@ -4,8 +4,6 @@
 #include "cmsis_os.h"
 #include "cerberus_conf.h"
 
-#define FAULT_HANDLE_QUEUE_SIZE 16
-
 typedef enum {
     DEFCON1 = 1,
     DEFCON2,
@@ -21,19 +19,14 @@ typedef enum {
     IMU_FAULT           = 0x4,
 } fault_code_t;
 
-//TODO: Make this queue not accessible to users,
-//  Make this into a wrapped function for "trigger_fault"
-//  and then expose _that_ to the user
 typedef struct {
     fault_code_t id;
     fault_sev_t severity;
     char *diag;
 } fault_data_t;
 
-//TODO: Make this queue not accessible to users,
-//  Make this into a wrapped function for "trigger_fault"
-//  and then expose _that_ to the user
-extern osMessageQueueId_t fault_handle_queue;
+/* Function to queue a fault */
+int queue_fault(fault_data_t *fault_data);
 
 /* Defining Fault Hanlder Task */
 void vFaultHandler(void *pv_params);

--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -131,7 +131,7 @@ void vCanDispatch(void* pv_params) {
 		if (osOK == osMessageQueueGet(can_outbound_queue, &msg_from_queue, NULL, 50)) {
 			if (can_send_message(msg_from_queue)) {
 				fault_data.diag = "Failed to send CAN message";
-				osMessageQueuePut(fault_handle_queue, &fault_data , 0U, 0U);
+				queue_fault(&fault_data);
 			}
 		}
 
@@ -140,22 +140,10 @@ void vCanDispatch(void* pv_params) {
 	}
 }
 
-void queue_can_msg(can_msg_t msg) {
-	
-	fault_data_t fault_data = {
-		.id = 2, /* this is arbitrary */
-		.severity = DEFCON4
-	};
-
-	if(!can_outbound_queue) {
+int queue_can_msg(can_msg_t msg) 
+{
+	if(!can_outbound_queue)
 		return 1;
-	}
 
-	if(osOK == osMessageQueuePut(can_outbound_queue, &msg, 0U, 0U)) {
-		return 0;
-	}
-
-	fault_data.diag = "Failed to put CAN message in queue";
-	osMessageQueuePut(fault_handle_queue, &fault_data , 0U, 0U);
-	return 1;
+	osMessageQueuePut(can_outbound_queue, &msg, 0U, 0U);
 }

--- a/Core/Src/fault.c
+++ b/Core/Src/fault.c
@@ -1,5 +1,7 @@
 #include "fault.h"
 
+#define FAULT_HANDLE_QUEUE_SIZE 16
+
 osMessageQueueId_t fault_handle_queue;
 
 osThreadId_t fault_handle;
@@ -9,28 +11,37 @@ const osThreadAttr_t fault_handle_attributes = {
 	.priority	= (osPriority_t)osPriorityISR,
 };
 
-//Function assign a priority and tell the kernel to schedule on boot
-void vFaultHandler(void* pv_params) {
+int queue_fault(fault_data_t *fault_data)
+{
+    if(!fault_handle_queue)
+		return 1;
+
+    osMessageQueuePut(fault_handle_queue, fault_data, 0U, 0U);
+}
+
+void vFaultHandler(void* pv_params) 
+{
     fault_data_t fault_data;
     osStatus_t status;
-    //Wait until a message is in the queue, send messages when they are in the queue
+    fault_handle_queue = osMessageQueueNew(FAULT_HANDLE_QUEUE_SIZE, sizeof(fault_data_t), NULL);
+
 	for(;;) {
-        status = osMessageQueueGet(fault_handle_queue, &fault_data, NULL, 0U);   // wait for message
+        /* Wait until a message is in the queue, send messages when they are in the queue */
+        status = osMessageQueueGet(fault_handle_queue, &fault_data, NULL, 0U);
         if (status == osOK) {
-        
-        // process data
+
         switch (fault_data.severity) {
-        case DEFCON1: //Higest(1st) Priority
+        case DEFCON1: /* Highest(1st) Priority */
             break;
-        case DEFCON2: //2nd Highest Priority
+        case DEFCON2:
             break;
-        case DEFCON3: //3rd Highest Priority
+        case DEFCON3:
             break;
-        case DEFCON4: //Slight Above Lowest Priority
+        case DEFCON4:
             break;
-        case DEFCON5: //Lowest Priority
+        case DEFCON5: /* Lowest Priority */
             break;
-        default: //Unable To Identify 'fault_sev_t'
+        default:
             break;
             }
         }

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -169,7 +169,6 @@ int main(void)
 
   /* USER CODE BEGIN RTOS_QUEUES */
   onboard_temp_queue = osMessageQueueNew(ONBOARD_TEMP_QUEUE_SIZE, sizeof(onboard_temp_t), NULL);
-  fault_handle_queue = osMessageQueueNew(FAULT_HANDLE_QUEUE_SIZE, sizeof(fault_data_t), NULL);
   imu_queue = osMessageQueueNew(IMU_QUEUE_SIZE, sizeof(imu_data_t), NULL);
   pedal_data_queue = osMessageQueueNew(PEDAL_DATA_QUEUE_SIZE, sizeof(pedals_t), NULL);
   /* USER CODE END RTOS_QUEUES */

--- a/Core/Src/monitor.c
+++ b/Core/Src/monitor.c
@@ -33,14 +33,14 @@ void vTempMonitor(void* pv_params)
 
 	if (sht30_init(&temp_sensor)) {
 		fault_data.diag = "Init Failed";
-		osMessageQueuePut(fault_handle_queue, &fault_data, 0U, 0U);
+		queue_fault(&fault_data);
 	}
 
 	for (;;) {
 		/* Take measurement */
 		if (sht30_get_temp_humid(&temp_sensor)) {
 			fault_data.diag = "Failed to get temp";
-			osMessageQueuePut(fault_handle_queue, &fault_data, 0U, 0U);
+			queue_fault(&fault_data);
 		}
 
 		/* Run values through LPF of sample size  */
@@ -54,7 +54,7 @@ void vTempMonitor(void* pv_params)
 		memcpy(temp_msg.data, &sensor_data, can_msg_len);
 		if (can_send_message(temp_msg)) {
 			fault_data.diag = "Failed to send CAN message";
-			osMessageQueuePut(fault_handle_queue, &fault_data, 0U, 0U);
+			queue_fault(&fault_data);
 		}
 
 		/* Yield to other tasks */
@@ -143,7 +143,7 @@ void vPedalsMonitor(void* pv_params)
 		memcpy(pedal_msg.data, &sensor_data, can_msg_len);
 		if (can_send_message(pedal_msg)) {
 			fault_data.diag = "Failed to send CAN message";
-			osMessageQueuePut(fault_handle_queue, &fault_data, 0U, 0U);
+			queue_fault(&fault_data);
 		}
 
 		/* Yield to other tasks */
@@ -190,19 +190,19 @@ void vIMUMonitor(void *pv_params)
 	/* Initialize IMU */
 	if (lsm6dso_init(&imu, hi2c1)) {
 		fault_data.diag = "Init Failed";
-		osMessageQueuePut(fault_handle_queue, &fault_data , 0U, 0U);
+		queue_fault(&fault_data);
 	}
 
 	for(;;) {
 		/* Take measurement */
 		if (lsm6dso_read_accel(&imu)) {
 			fault_data.diag = "Failed to get IMU acceleration";
-			osMessageQueuePut(fault_handle_queue, &fault_data , 0U, 0U);
+			queue_fault(&fault_data);
 		}
 
 		if (lsm6dso_read_gyro(&imu)) {
 			fault_data.diag = "Failed to get IMU gyroscope";
-			osMessageQueuePut(fault_handle_queue, &fault_data , 0U, 0U);
+			queue_fault(&fault_data);
 		}
 
 		/* Run values through LPF of sample size  */
@@ -226,13 +226,13 @@ void vIMUMonitor(void *pv_params)
 		memcpy(imu_accel_msg.data, &sensor_data, accel_msg_len);
 		if (can_send_message(imu_accel_msg)) {
 			fault_data.diag = "Failed to send CAN message";
-			osMessageQueuePut(fault_handle_queue, &fault_data , 0U, 0U);
+			queue_fault(&fault_data);
 		}
 		
 		memcpy(imu_gyro_msg.data, &sensor_data, gyro_msg_len);
 		if (can_send_message(imu_gyro_msg)) {
 			fault_data.diag = "Failed to send CAN message";
-			osMessageQueuePut(fault_handle_queue, &fault_data , 0U, 0U);
+			queue_fault(&fault_data);
 		}
 
 		/* Yield to other tasks */


### PR DESCRIPTION
## Changes

I added a function to queue a fault so that functions don't have to make a call to the fault handler directly

## Notes

Also I removed references to the fault queue in favor of using this new function instead

## Test Cases

Made sure it built in docker

Ran on renode, ensured that a fault would be queued

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please reach out to your Project Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] All commits are tagged with the ticket number
- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #94 (issue #)
