### PR TITLE
Adding in the fuse monitor task and starting it in main

### DIFF
--- a/Core/Inc/cerberus_conf.h
+++ b/Core/Inc/cerberus_conf.h
@@ -3,6 +3,7 @@
 #define TEMP_SENS_SAMPLE_DELAY  200 /* ms */
 #define IMU_SAMPLE_DELAY        50  /* ms */
 #define PEDALS_SAMPLE_DELAY     5   /* ms */
+#define FUSES_SAMPLE_DELAY      200 /* ms */
 #define SERIAL_MONITOR_DELAY
 #define CAN_ROUTER_DELAY
 #define CAN_DISPATCH_DELAY
@@ -43,3 +44,4 @@
 #define CANID_TEMP_SENSOR 0xBEEF
 #define CANID_OUTBOUND_MSG 0xA55
 #define CANID_TORQUE_MSG 0xBA115
+#define CANID_FUSE  0x111

--- a/Core/Inc/fault.h
+++ b/Core/Inc/fault.h
@@ -19,6 +19,8 @@ typedef enum {
     IMU_FAULT           = 0x4,
     CAN_DISPATCH_FAULT  = 0x8,
     CAN_ROUTING_FAULT   = 0x10,
+    FUSE_MONITOR_FAULT  = 0x20,
+    MAX_FAULTS
 } fault_code_t;
 
 typedef struct {

--- a/Core/Inc/monitor.h
+++ b/Core/Inc/monitor.h
@@ -36,4 +36,9 @@ void vIMUMonitor(void *pv_params);
 extern osThreadId_t imu_monitor_handle;
 extern const osThreadAttr_t imu_monitor_attributes;
 
+/* Task for Monitoring the Fuses on PDU */
+void vFusingMonitor(void *pv_params);
+extern osThreadId_t fusing_monitor_handle;
+extern const osThreadAttr_t fusing_monitor_attributes;
+
 #endif // MONITOR_H

--- a/Core/Inc/pdu.h
+++ b/Core/Inc/pdu.h
@@ -31,7 +31,8 @@ typedef enum {
     FUSE_LVBOX,
     FUSE_DASHBOARD,
     FUSE_BRAKELIGHT,
-    FUSE_BRB
+    FUSE_BRB,
+    MAX_FUSES
 } fuse_t;
 
 int8_t read_fuse(pdu_t *pdu, fuse_t fuse, bool *status);

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -23,6 +23,7 @@
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
 #include <stdio.h>
+#include <stdlib.h>
 #include "sht30.h"
 #include "lsm6dso.h"
 #include "monitor.h"
@@ -32,6 +33,7 @@
 #include "serial_monitor.h"
 #include "state_machine.h"
 #include "torque.h"
+#include "pdu.h"
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -194,6 +196,8 @@ int main(void)
   pedal_params->accel_adc2 = &hadc2;
   pedal_params->brake_adc = &hadc3;
 
+  pdu_t *pdu = init_pdu(&hi2c1);
+
   pedal_data_queue = osMessageQueueNew(PEDAL_DATA_QUEUE_SIZE, sizeof(pedals_t), NULL);
   /* USER CODE END RTOS_QUEUES */
 
@@ -207,7 +211,8 @@ int main(void)
   watchdog_monitor_handle = osThreadNew(vWatchdogMonitor, GPIOB, &watchdog_monitor_attributes);
   imu_monitor_handle = osThreadNew(vIMUMonitor, &hi2c1, &imu_monitor_attributes);
   pedals_monitor_handle = osThreadNew(vPedalsMonitor, pedal_params, &pedals_monitor_attributes);
-  
+  fusing_monitor_handle = osThreadNew(vFusingMonitor, pdu, &fusing_monitor_attributes);
+
   /* Hardware Messaging */
   /* Note that CAN Router initializes CAN */
   route_can_incoming_handle = osThreadNew(vRouteCanIncoming, &hcan1, &route_can_incoming_attributes);

--- a/Core/Src/monitor.c
+++ b/Core/Src/monitor.c
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <stdbool.h>
 #include "monitor.h"
 #include "can.h"
 #include "cerberus_conf.h"
@@ -10,6 +11,7 @@
 #include "lsm6dso.h"
 #include "serial_monitor.h"
 #include "timer.h"
+#include "pdu.h"
 
 osThreadId_t temp_monitor_handle;
 const osThreadAttr_t temp_monitor_attributes = {
@@ -279,5 +281,48 @@ void vIMUMonitor(void *pv_params)
 
 		/* Yield to other tasks */
 		osDelay(imu_sample_delay);
+	}
+}
+
+osThreadId_t fusing_monitor_handle;
+const osThreadAttr_t fusing_monitor_attributes = {
+	.name = "FusingMonitor",
+	.stack_size = 128 * 8,
+	.priority = (osPriority_t) osPriorityNormal3,
+};
+
+void vFusingMonitor(void *pv_params)
+{
+	const uint8_t fuse_msg_len = 8;
+
+	fault_data_t fault_data = {
+		.id = FUSE_MONITOR_FAULT,
+		.severity = DEFCON3
+	};
+
+	can_msg_t fuse_msg = {
+		.id = CANID_FUSE,
+		.len = 8,
+		.data = {0}
+	};
+
+	I2C_HandleTypeDef *hi2c1 = (I2C_HandleTypeDef *)pv_params;
+
+	pdu_t *pdu = init_pdu(hi2c1);
+
+	bool fuses[MAX_FUSES] = { 0 };
+
+	for (;;) {
+		for (fuse_t fuse; fuse < MAX_FUSES; fuse++) {
+			read_fuse(pdu, fuse, &fuses[fuse]);
+		}
+
+		memcpy(fuse_msg.data, &fuses, 8);
+		if (queue_can_msg(fuse_msg)) {
+			fault_data.diag = "Failed to send CAN message";
+			queue_fault(&fault_data);
+		}
+
+		osDelay(FUSES_SAMPLE_DELAY);
 	}
 }


### PR DESCRIPTION
## Changes

This is an RTOS task that will monitor the status of the fuses onboard the PDU via the software PDU interface.

## Notes

Note that the PDU interface is not fully implemented, but basic mutex functionality was tested

Closes #114 
