### PR TITLE
Moving the location of CAN init to main to prevent race conditions

### DIFF
--- a/Core/Inc/can_handler.h
+++ b/Core/Inc/can_handler.h
@@ -26,5 +26,6 @@ extern osThreadId_t can_dispatch_handle;
 extern const osThreadAttr_t can_dispatch_attributes;
 
 int8_t queue_can_msg(can_msg_t msg);
+can_t *init_can1(CAN_HandleTypeDef *hcan);
 
 #endif

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -165,6 +165,7 @@ int main(void)
   /* Create Interfaces to Represent Relevant Hardware */
   mpu_t *mpu = init_mpu(&hi2c1, &hadc1, &hadc2, &hadc3, GPIOC, GPIOB);
   pdu_t *pdu = init_pdu(&hi2c2);
+  can_t *can1 = init_can1(&hcan1);
 
   toggle_yled(mpu); // Toggle on LED2
   HAL_Delay(500);
@@ -212,8 +213,8 @@ int main(void)
 
   /* Hardware Messaging */
   /* Note that CAN Router initializes CAN */
-  route_can_incoming_handle = osThreadNew(vRouteCanIncoming, &hcan1, &route_can_incoming_attributes);
-  can_dispatch_handle = osThreadNew(vCanDispatch, &hcan1, &can_dispatch_attributes);
+  route_can_incoming_handle = osThreadNew(vRouteCanIncoming, NULL, &route_can_incoming_attributes);
+  can_dispatch_handle = osThreadNew(vCanDispatch, can1, &can_dispatch_attributes);
   serial_monitor_handle = osThreadNew(vSerialMonitor, NULL, &serial_monitor_attributes);
 
   /* Control Logic */


### PR DESCRIPTION
## Changes

Moving the location of CAN init to main to prevent race conditions

## Notes

This worked fairly cleanly

Closes #119
