### PR TITLE
113 steering wheel

### DIFF
--- a/Core/Inc/cerberus_conf.h
+++ b/Core/Inc/cerberus_conf.h
@@ -12,6 +12,8 @@
 #define TORQUE_CALC_DELAY
 #define FAULT_HANDLE_DELAY
 
+#define STEERING_WHEEL_DEBOUNCE 100  /* ms */
+
 /* Pin Assignments */
 #define FAULT_MCU_Pin                       GPIO_PIN_3
 #define FAULT_MCU_GPIO_Port                 GPIOC

--- a/Core/Inc/steeringio.h
+++ b/Core/Inc/steeringio.h
@@ -1,0 +1,104 @@
+Button::Button(){}
+
+Button::~Button(){}
+
+void Button::checkButtonPin()
+{
+    if(isPressed == true && state == NOT_PRESSED)
+    {
+        state = DEBOUNCING;
+        debounce.startTimer(BUTTON_DEBOUNCE_TIME);
+    }
+    else if(isPressed == false)
+    {
+        debounce.cancelTimer();
+        state = NOT_PRESSED;
+    }
+}
+
+bool Button::isButtonPressed()
+{
+    if(state == PRESSED) return true;
+
+    /**
+     * Returns true if
+     * 1. The button has successfully passed the debounce period
+     * 2. The debounce timer has not been canceled/reset
+     * 3. The button is still being held
+     */
+    if(isPressed && debounce.isTimerExpired() && !debounce.isTimerReset())
+    {
+        state = PRESSED;
+        return true;
+    }
+    return false;
+}
+
+bool Button::isButtonPressed_Pulse()
+{
+    if(state == PRESSED) return false;
+
+    /**
+     * Returns true if
+     * 1. The button has successfully passed the debounce period
+     * 2. The debounce timer has not been canceled/reset
+     * 3. The button is still being held
+     * 
+     * AND
+     * 
+     * 4. The state of the button has not been read since the button has passed the debounce
+     */
+    if(isPressed && debounce.isTimerExpired() && !debounce.isTimerReset())
+    {
+        state = PRESSED;
+        return true;
+    }
+
+    return false;
+}
+
+void Button::setButtonState(bool buttonState)
+{
+    isPressed = buttonState;
+}
+
+void DriverIO::wheelIO_cb(const CAN_message_t &msg)
+{
+    union
+    {
+        uint8_t msg[8];
+
+        struct
+        {
+            uint16_t pot_l;
+            uint16_t pot_r;
+            bool button5 : 1;
+            bool button6 : 1;
+            bool button3 : 1;
+            uint8_t x1   : 1;
+            bool paddle_r : 1;
+            bool paddle_l : 1;
+            bool button4 : 1;
+            bool button2 : 1;
+            uint8_t x2;
+            uint8_t x3;
+            uint8_t x4;
+        } io;
+    } wheelio;
+
+    for(uint8_t byte = 0; byte < 8; byte++)
+    {
+        wheelio.msg[byte] = msg.buf[byte];
+    }
+
+    wheelio.io.pot_l = SWITCHBYTES(wheelio.io.pot_l);
+    wheelio.io.pot_r = SWITCHBYTES(wheelio.io.pot_r);
+
+    decrButton.setButtonState(wheelio.io.button2);
+    incrButton.setButtonState(wheelio.io.button4);
+    regenButton.setButtonState(wheelio.io.button5);
+    torqueIncreasePaddle.setButtonState(wheelio.io.paddle_r);
+    torqueDecreasePaddle.setButtonState(wheelio.io.paddle_l);
+    accumulatorFanDial.setDialValue(wheelio.io.pot_l);
+    motorFanDial.setDialValue(wheelio.io.pot_r);
+}

--- a/Core/Src/steeringio.c
+++ b/Core/Src/steeringio.c
@@ -1,0 +1,109 @@
+#include "steeringio.h"
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include "cmsis_os.h"
+#include "cerberus_conf.h"
+
+static osMutexAttr_t steeringio_data_mutex_attributes;
+static osMutexAttr_t steeringio_ringbuffer_mutex_attributes;
+
+static void debounce_cb(void const *arg);
+osTimerDef(debounce_timer, debounce_cb);
+
+enum {
+	NOT_PRESSED,
+	PRESSED
+};
+
+/* Creates a new Steering Wheel interface */
+steeringio_t *steeringio_init()
+{
+	steeringio_t *steeringio = malloc(sizeof(steeringio_t));
+	assert(steeringio);
+
+	/* Create Mutexes */
+	steeringio->ringbuffer_mutex = osMutexNew(&steeringio_data_mutex_attributes);
+	assert(steeringio->ringbuffer_mutex);
+
+	steeringio->button_mutex = osMutexNew(&steeringio_ringbuffer_mutex_attributes);
+	assert(steeringio->button_mutex);
+
+	for (uint8_t i = 0; i < MAX_STEERING_BUTTONS; i++) {
+		steeringio->debounce_timers[i] = osTimerCreate(osTimer(debounce_timer), osTimerOnce, steeringio);
+		assert(steeringio->debounce_timers[i]);
+	}
+
+	steeringio->debounce_buffer = ringbuffer_create(MAX_STEERING_BUTTONS, sizeof(uint8_t));
+	assert(steeringio->debounce_buffer);
+
+	return steeringio;
+}
+
+bool get_steeringio_button(steeringio_t *wheel, steeringio_button_t button)
+{
+	if (!wheel)
+		return 0;
+
+	bool ret = 0;
+
+	osMutexAcquire(wheel->button_mutex, osWaitForever);
+	ret = wheel->debounced_buttons[button];
+	osMutexRelease(wheel->button_mutex);
+
+	return ret;
+}
+
+/* Callback to see if we have successfully debounced */
+static void debounce_cb(void const *arg)
+{
+	steeringio_t *wheel = (steeringio_t *)arg;
+	if (!wheel)
+		return;
+
+	steeringio_button_t button;
+
+	/*
+	 * Pop off most recent button being debounced
+	 * Note: timers are started sequentially, therefore buttons
+	 *  will be popped off in order
+	 *
+	 * Also needs to be atomic
+	 */
+	osMutexAcquire(wheel->ringbuffer_mutex, osWaitForever);
+	ringbuffer_dequeue(wheel->debounce_buffer, &button);
+	osMutexRelease(wheel->ringbuffer_mutex);
+
+	if (!button)
+		return;
+
+	if (wheel->raw_buttons[button])
+		wheel->debounced_buttons[button] = PRESSED;
+}
+
+/* For updating values via the wheel's CAN message */
+void steeringio_update(steeringio_t *wheel, uint8_t wheel_data[], uint8_t len)
+{
+	if (!wheel || !wheel_data)
+		return;
+
+	//TODO: Revisit how new wheel's data is formatted
+	/* Copy message data to wheelio buffer */
+	//memcpy(&io, wheel_data, len);
+
+	/* If the value was set high and is not being debounced, trigger timer for debounce */
+	osMutexAcquire(wheel->button_mutex, osWaitForever);
+	for (uint8_t i = 0; i < MAX_STEERING_BUTTONS; i++) {
+		if (wheel->debounced_buttons[i] && wheel->raw_buttons[i]) {
+			wheel->debounced_buttons[i] = PRESSED;
+		}
+		else if (wheel->raw_buttons[i] && !osTimerIsRunning(wheel->debounce_timers[i])) {
+			osTimerStart(wheel->debounce_timers[i], STEERING_WHEEL_DEBOUNCE);
+			ringbuffer_enqueue(wheel->debounce_buffer, &i);
+		}
+		else {
+			wheel->debounced_buttons[i] = NOT_PRESSED;
+		}
+	}
+	osMutexRelease(wheel->button_mutex);
+}

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ Core/Src/state_machine.c \
 Core/Src/torque.c \
 Core/Src/pdu.c \
 Core/Src/mpu.c \
+Core/Src/steeringio.c \
 Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_can.c \
 Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_rcc.c \
 Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_rcc_ex.c \
@@ -79,6 +80,7 @@ Drivers/Embedded-Base/general/src/sht30.c \
 Drivers/Embedded-Base/platforms/stm32f405/src/can.c \
 Drivers/Embedded-Base/general/src/pi4ioe.c \
 Drivers/Embedded-Base/middleware/src/timer.c \
+Drivers/Embedded-Base/middleware/src/ringbuffer.c \
 Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_adc.c \
 Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_adc_ex.c \
 Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_adc.c \


### PR DESCRIPTION
## Changes

I've created a basic interface for updating and retrieving button data sent from the steering wheel

## Notes

The basic implementation is that I wanted to make each operation from the user atomic, since I am leveraging the ability to spawn timer based callbacks.

My implementation of debouncing is that:
1. CAN message updates raw fields
2. If the raw field goes from 0 to 1, we start time debounce timer for that specific button, else we set it to 0
3. The struct contains an array of timers that all call the same callback, so we also have them push a new debounce request to the ringbuffer
4. Callback pops off the most recent request to the ring buffer and evaluates if the button is pressed, then update that in the steering struct

## Test Cases

- lmao it builds

## To Do

I think I need to evaluate the buffer for the case when a timer is restarted. I.e. how can we handle it when the same button goes up then down then up (would queue 2 and callback wouldn't know what to do)

Closes #113 
