### PR TITLE
125 canroute

### DIFF
--- a/Core/Inc/dti.h
+++ b/Core/Inc/dti.h
@@ -41,7 +41,13 @@ typedef struct {
 
 //TODO: Expand GET interface
 
-dti_t *dti_init()
+/* Utilities for Decoding CAN message */
+extern osThreadId_t dti_router_handle;
+extern const osThreadAttr_t dti_router_attributes;
+extern osMessageQueueId_t dti_router_queue;
+void vDTIRouter(void* pv_params);
+
+dti_t *dti_init();
 
 /*
  * SCALE: 10
@@ -81,8 +87,5 @@ void dti_set_relative_current(int16_t relative_current);
  * UNITS: No units
  */
 void dti_set_drive_enable(bool drive_enable);
-
-/* Used to update local fields of MC Interface */
-void dti_update(dti_t* mc, can_msg_t *msg);
 
 #endif

--- a/Core/Inc/dti.h
+++ b/Core/Inc/dti.h
@@ -16,23 +16,32 @@
 #include <stdbool.h>
 #include "can_handler.h"
 
+/* Message IDs from DTI CAN Datasheet */
+#define DTI_CANID_ERPM          0x20 /* ERPM, Duty, Input Voltage */
+#define DTI_CANID_CURRENTS      0x21 /* AC Current, DC Current */
+#define DTI_CANID_TEMPS_FAULT   0x22 /* Controller Temp, Motor Temp, Faults */
+#define DTI_CANID_ID_IQ         0x23 /* Id, Iq values */
+#define DTI_CANID_SIGNALS       0x24 /* Throttle signal, Brake signal, IO, Drive enable */
+
+
 typedef struct {
     int32_t rpm;            /* SCALE: 1         UNITS: Rotations per Minute   */
     int16_t duty_cycle;     /* SCALE: 10        UNITS: Percentage             */
     int16_t input_voltage;  /* SCALE: 1         UNITS: Volts                  */
     int16_t ac_current;     /* SCALE: 10        UNITS: Amps                   */
     int16_t dc_current;     /* SCALE: 10        UNITS: Amps                   */
-    int16_t cont_temp;      /* SCALE: 10        UNITS: Degrees Celsius        */
+    int16_t contr_temp;      /* SCALE: 10        UNITS: Degrees Celsius        */
     int16_t motor_temp;     /* SCALE: 10        UNITS: Degrees Celsius        */
     uint8_t fault_code;     /* SCALE: 1         UNITS: No units just a number */
     int8_t throttle_signal; /* SCALE: 1         UNITS: Percentage             */
     int8_t brake_signal;    /* SCALE: 1         UNITS: Percentage             */
     int8_t drive_enable;    /* SCALE: 1         UNITS: No units just a number */
+    osMutexId_t *mutex;
 } dti_t;
 
 //TODO: Expand GET interface
 
-void dti_init(dti_t* mc);
+dti_t *dti_init()
 
 /*
  * SCALE: 10
@@ -40,11 +49,8 @@ void dti_init(dti_t* mc);
  */
 void dti_set_torque(int16_t torque);
 
-/*
- * SCALE: bool
- * UNITS: No units
- */
-void dti_get_drive_enable(dti_t* mc);
+//TODO: Regen interface
+//void dti_set_regen(int16_t regen);
 
 /*
  * SCALE: 10
@@ -54,44 +60,29 @@ void dti_set_brake_current(int16_t brake_current);
 
 /*
  * SCALE: 10
+ * UNITS: Percentage of max
+ */
+void dti_set_relative_brake_current(int16_t relative_brake_current);
+
+/*
+ * SCALE: 10
  * UNITS: Amps
  */
 void dti_set_current(int16_t current);
 
 /*
- * SCALE: 1
- * UNITS: RPM
- */
-void dti_set_speed(int32_t rpm);
-
-/*
  * SCALE: 10
- * UNITS: Degrees
- */
-void dti_set_position(int16_t angle);
-
-/*
- * SCALE: 10
- * UNITS: Percentage
+ * UNITS: Percentage of max
  */
 void dti_set_relative_current(int16_t relative_current);
-
-/*
- * SCALE: 10
- * UNITS: Percentage
- */
-void dti_set_relative_brake_current(int16_t relative_brake_current);
-
-/*
- * SCALE: 1
- * UNITS: No units
- */
-void dti_set_digital_output(uint8_t output, bool value);
 
 /*
  * SCALE: bool
  * UNITS: No units
  */
 void dti_set_drive_enable(bool drive_enable);
+
+/* Used to update local fields of MC Interface */
+void dti_update(dti_t* mc, can_msg_t *msg);
 
 #endif

--- a/Core/Inc/fault.h
+++ b/Core/Inc/fault.h
@@ -21,6 +21,7 @@ typedef enum {
     CAN_ROUTING_FAULT   = 0x10,
     FUSE_MONITOR_FAULT  = 0x20,
     SHUTDOWN_MONITOR_FAULT = 0x40,
+    DTI_ROUTING_FAULT   = 0x80,
     MAX_FAULTS
 } fault_code_t;
 

--- a/Core/Inc/fault.h
+++ b/Core/Inc/fault.h
@@ -22,7 +22,7 @@ typedef enum {
     FUSE_MONITOR_FAULT          = 0x20,
     SHUTDOWN_MONITOR_FAULT      = 0x40,
     DTI_ROUTING_FAULT           = 0x80,
-    STEERINGIO_ROUTING_FAULT    = 0x100
+    STEERINGIO_ROUTING_FAULT    = 0x100,
     MAX_FAULTS
 } fault_code_t;
 

--- a/Core/Inc/fault.h
+++ b/Core/Inc/fault.h
@@ -13,15 +13,16 @@ typedef enum {
 } fault_sev_t;
 
 typedef enum {
-    FAULTS_CLEAR        = 0x0,
-    ONBOARD_TEMP_FAULT  = 0x1,
-    ONBOARD_PEDAL_FAULT = 0x2,
-    IMU_FAULT           = 0x4,
-    CAN_DISPATCH_FAULT  = 0x8,
-    CAN_ROUTING_FAULT   = 0x10,
-    FUSE_MONITOR_FAULT  = 0x20,
-    SHUTDOWN_MONITOR_FAULT = 0x40,
-    DTI_ROUTING_FAULT   = 0x80,
+    FAULTS_CLEAR                = 0x0,
+    ONBOARD_TEMP_FAULT          = 0x1,
+    ONBOARD_PEDAL_FAULT         = 0x2,
+    IMU_FAULT                   = 0x4,
+    CAN_DISPATCH_FAULT          = 0x8,
+    CAN_ROUTING_FAULT           = 0x10,
+    FUSE_MONITOR_FAULT          = 0x20,
+    SHUTDOWN_MONITOR_FAULT      = 0x40,
+    DTI_ROUTING_FAULT           = 0x80,
+    STEERINGIO_ROUTING_FAULT    = 0x100
     MAX_FAULTS
 } fault_code_t;
 

--- a/Core/Inc/steeringio.h
+++ b/Core/Inc/steeringio.h
@@ -26,6 +26,12 @@ typedef struct {
 	bool debounced_buttons[MAX_STEERING_BUTTONS];
 } steeringio_t;
 
+/* Utilities for Decoding CAN message */
+extern osThreadId_t steeringio_router_handle;
+extern const osThreadAttr_t steeringio_router_attributes;
+extern osMessageQueueId_t steeringio_router_queue;
+void vSteeringIORouter(void* pv_params);
+
 /* Creates a new Steering Wheel interface */
 steeringio_t *steeringio_init();
 

--- a/Core/Inc/steeringio.h
+++ b/Core/Inc/steeringio.h
@@ -6,6 +6,8 @@
 #include "ringbuffer.h"
 #include "cmsis_os.h"
 
+#define STEERING_CANID_IO	0x400
+
 typedef enum {
 	STEERING_PADDLE_LEFT,
 	STEERING_PADDLE_RIGHT,

--- a/Core/Inc/torque.h
+++ b/Core/Inc/torque.h
@@ -16,6 +16,6 @@
 
 void vCalcTorque(void* pv_params);
 extern osThreadId_t torque_calc_handle;
-extern const osThreadAttr_t  torque_calc_attributes;
+extern const osThreadAttr_t torque_calc_attributes;
 
 #endif

--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -21,9 +21,6 @@
 
 #define CAN_MSG_QUEUE_SIZE 25 /* messages */
 
-/* Queue for Inbound CAN Messages */
-static osMessageQueueId_t can_inbound_queue;
-
 /* Relevant Info for Initializing CAN 1 */
 static uint16_t id_list[] = {
 	DTI_CANID_ERPM,

--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -18,6 +18,7 @@
 #include <stdlib.h>
 #include "cerberus_conf.h"
 #include "dti.h"
+#include "steeringio.h"
 
 #define CAN_MSG_QUEUE_SIZE 25 /* messages */
 
@@ -27,7 +28,8 @@ static uint16_t id_list[] = {
 	DTI_CANID_CURRENTS,
 	DTI_CANID_TEMPS_FAULT,
 	DTI_CANID_ID_IQ,
-	DTI_CANID_SIGNALS
+	DTI_CANID_SIGNALS,
+	STEERING_CANID_IO,
 };
 
 void can1_callback(CAN_HandleTypeDef *hcan);
@@ -72,7 +74,7 @@ void can1_callback(CAN_HandleTypeDef *hcan)
 	new_msg.id = rx_header.StdId;
 
 	//TODO: Switch to hash map
-	switch(new_msg.len) {
+	switch(new_msg.id) {
 		/* Messages Relevant to Motor Controller */
 		case DTI_CANID_ERPM:
 		case DTI_CANID_CURRENTS:
@@ -80,6 +82,9 @@ void can1_callback(CAN_HandleTypeDef *hcan)
 		case DTI_CANID_ID_IQ:
 		case DTI_CANID_SIGNALS:
 			osMessageQueuePut(dti_router_queue, &new_msg, 0U, 0U);
+			break;
+		case STEERING_CANID_IO:
+			osMessageQueuePut(steeringio_router_queue, &new_msg, 0U, 0U);
 			break;
 		default:
 			break;

--- a/Core/Src/dti.c
+++ b/Core/Src/dti.c
@@ -11,11 +11,16 @@
 
 #include <string.h>
 #include <assert.h>
+#include <stdlib.h>
 #include "dti.h"
 #include "can.h"
 #include "emrax.h"
+#include "fault.h"
+
+#define CAN_QUEUE_SIZE      5   /* messages */
 
 static osMutexAttr_t dti_mutex_attributes;
+osMessageQueueId_t dti_router_queue;
 
 dti_t *dti_init()
 {
@@ -31,6 +36,12 @@ dti_t *dti_init()
 	//dti_set_max_ac_current();
 	//dti_set_max_dc_brake_current();
 	//dti_set_max_dc_current();
+
+	/* Create Queue for CAN signaling */
+    dti_router_queue = osMessageQueueNew(CAN_QUEUE_SIZE, sizeof(can_msg_t), NULL);
+    assert(dti_router_queue);
+
+	return mc;
 }
 
 void dti_set_torque(int16_t torque)
@@ -163,18 +174,38 @@ void dti_set_drive_enable(bool drive_enable)
 	queue_can_msg(msg);
 }
 
-void dti_update(dti_t* mc, can_msg_t *msg)
+/* Inbound Task-specific Info */
+osThreadId_t dti_router_handle;
+const osThreadAttr_t dti_router_attributes = {
+	.name = "DTIRouter",
+	.stack_size = 128 * 8,
+	.priority = (osPriority_t)osPriorityNormal3
+};
+
+void vDTIRouter(void* pv_params)
 {
-	switch(msg->id) {
-		case DTI_CANID_ERPM:
-			break;
-		case DTI_CANID_CURRENTS:
-			break;
-		case DTI_CANID_TEMPS_FAULT:
-			break;
-		case DTI_CANID_SIGNALS:
-			break;
-		default:
-			break;
+	can_msg_t message;
+	osStatus_t status;
+	//fault_data_t fault_data = { .id = DTI_ROUTING_FAULT, .severity = DEFCON2 };
+
+	for (;;) {
+		/* Wait until new CAN message comes into queue */
+		status = osMessageQueueGet(dti_router_queue, &message, NULL, osWaitForever);
+		if (status == osOK){
+			switch(message.id) {
+				case DTI_CANID_ERPM:
+					break;
+				case DTI_CANID_CURRENTS:
+					break;
+				case DTI_CANID_TEMPS_FAULT:
+					break;
+				case DTI_CANID_ID_IQ:
+					break;
+				case DTI_CANID_SIGNALS:
+					break;
+				default:
+					break;
+			}
+		}
 	}
 }

--- a/Core/Src/dti.c
+++ b/Core/Src/dti.c
@@ -10,12 +10,22 @@
  */
 
 #include <string.h>
+#include <assert.h>
 #include "dti.h"
 #include "can.h"
 #include "emrax.h"
 
-void dti_init(dti_t* mc)
+static osMutexAttr_t dti_mutex_attributes;
+
+dti_t *dti_init()
 {
+	dti_t *mc = malloc(sizeof(dti_t));
+	assert(mc);
+
+	/* Create Mutex */
+    mc->mutex = osMutexNew(&dti_mutex_attributes);
+    assert(mc->mutex);
+
 	//TODO: Set safety parameters for operation (maxes, mins, etc)
 	//dti_set_max_ac_brake_current();
 	//dti_set_max_ac_current();
@@ -151,4 +161,20 @@ void dti_set_drive_enable(bool drive_enable)
 	/* Send CAN message */
 	memcpy(msg.data, &drive_enable, msg.len);
 	queue_can_msg(msg);
+}
+
+void dti_update(dti_t* mc, can_msg_t *msg)
+{
+	switch(msg->id) {
+		case DTI_CANID_ERPM:
+			break;
+		case DTI_CANID_CURRENTS:
+			break;
+		case DTI_CANID_TEMPS_FAULT:
+			break;
+		case DTI_CANID_SIGNALS:
+			break;
+		default:
+			break;
+	}
 }

--- a/Core/Src/dti.c
+++ b/Core/Src/dti.c
@@ -188,6 +188,8 @@ void vDTIRouter(void* pv_params)
 	osStatus_t status;
 	//fault_data_t fault_data = { .id = DTI_ROUTING_FAULT, .severity = DEFCON2 };
 
+	//dti_t *mc = (dti_t *)pv_params;
+
 	for (;;) {
 		/* Wait until new CAN message comes into queue */
 		status = osMessageQueueGet(dti_router_queue, &message, NULL, osWaitForever);

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -35,6 +35,7 @@
 #include "torque.h"
 #include "pdu.h"
 #include "mpu.h"
+#include "dti.h"
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -213,7 +214,7 @@ int main(void)
 
   /* Hardware Messaging */
   /* Note that CAN Router initializes CAN */
-  route_can_incoming_handle = osThreadNew(vRouteCanIncoming, NULL, &route_can_incoming_attributes);
+  dti_router_handle = osThreadNew(vDTIRouter, NULL, &dti_router_attributes);
   can_dispatch_handle = osThreadNew(vCanDispatch, can1, &can_dispatch_attributes);
   serial_monitor_handle = osThreadNew(vSerialMonitor, NULL, &serial_monitor_attributes);
 

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -163,9 +163,18 @@ int main(void)
   MX_ADC3_Init();
   /* USER CODE BEGIN 2 */
 
+  /* USER CODE END 2 */
+
+  /* Init scheduler */
+  osKernelInitialize();
+
+  /* USER CODE BEGIN RTOS_MUTEX */
+  /* I'm not defining mutexes here lol */
+
   /* Create Interfaces to Represent Relevant Hardware */
-  mpu_t *mpu = init_mpu(&hi2c1, &hadc1, &hadc2, &hadc3, GPIOC, GPIOB);
-  pdu_t *pdu = init_pdu(&hi2c2);
+  mpu_t *mpu  = init_mpu(&hi2c1, &hadc1, &hadc2, &hadc3, GPIOC, GPIOB);
+  pdu_t *pdu  = init_pdu(&hi2c2);
+  dti_t *mc   = dti_init();
   can_t *can1 = init_can1(&hcan1);
 
   toggle_yled(mpu); // Toggle on LED2
@@ -176,13 +185,6 @@ int main(void)
   HAL_Delay(500);
   toggle_yled(mpu); // Toggle on LED2
 
-  /* USER CODE END 2 */
-
-  /* Init scheduler */
-  osKernelInitialize();
-
-  /* USER CODE BEGIN RTOS_MUTEX */
-  /* add mutexes, ... */
   /* USER CODE END RTOS_MUTEX */
 
   /* USER CODE BEGIN RTOS_SEMAPHORES */
@@ -220,7 +222,7 @@ int main(void)
 
   /* Control Logic */
   sm_director_handle = osThreadNew(vStateMachineDirector, NULL, &sm_director_attributes);
-  torque_calc_handle = osThreadNew(vCalcTorque, NULL, &torque_calc_attributes);
+  torque_calc_handle = osThreadNew(vCalcTorque, mc, &torque_calc_attributes);
   fault_handle = osThreadNew(vFaultHandler, NULL, &fault_handle_attributes);
 
   /* USER CODE END RTOS_THREADS */

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -36,6 +36,7 @@
 #include "pdu.h"
 #include "mpu.h"
 #include "dti.h"
+#include "steeringio.h"
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -175,6 +176,7 @@ int main(void)
   mpu_t *mpu  = init_mpu(&hi2c1, &hadc1, &hadc2, &hadc3, GPIOC, GPIOB);
   pdu_t *pdu  = init_pdu(&hi2c2);
   dti_t *mc   = dti_init();
+  steeringio_t *wheel = steeringio_init();
   can_t *can1 = init_can1(&hcan1);
 
   toggle_yled(mpu); // Toggle on LED2
@@ -216,7 +218,8 @@ int main(void)
 
   /* Hardware Messaging */
   /* Note that CAN Router initializes CAN */
-  dti_router_handle = osThreadNew(vDTIRouter, NULL, &dti_router_attributes);
+  dti_router_handle = osThreadNew(vDTIRouter, mc, &dti_router_attributes);
+  steeringio_router_handle = osThreadNew(vSteeringIORouter, wheel, &steeringio_router_attributes);
   can_dispatch_handle = osThreadNew(vCanDispatch, can1, &can_dispatch_attributes);
   serial_monitor_handle = osThreadNew(vSerialMonitor, NULL, &serial_monitor_attributes);
 

--- a/Core/Src/steeringio.c
+++ b/Core/Src/steeringio.c
@@ -127,7 +127,7 @@ void vSteeringIORouter(void* pv_params)
 {
 	can_msg_t message;
 	osStatus_t status;
-	//fault_data_t fault_data = { .id = DTI_ROUTING_FAULT, .severity = DEFCON2 };
+	//fault_data_t fault_data = { .id = STEERINGIO_ROUTING_FAULT, .severity = DEFCON2 };
 
 	steeringio_t *wheel = (steeringio_t *)pv_params;
 

--- a/Core/Src/steeringio.c
+++ b/Core/Src/steeringio.c
@@ -12,8 +12,7 @@ static osMutexAttr_t steeringio_data_mutex_attributes;
 static osMutexAttr_t steeringio_ringbuffer_mutex_attributes;
 osMessageQueueId_t steeringio_router_queue;
 
-static void debounce_cb(void const *arg);
-osTimerDef(debounce_timer, debounce_cb);
+static void debounce_cb(void *arg);
 
 enum {
 	NOT_PRESSED,
@@ -35,7 +34,7 @@ steeringio_t *steeringio_init()
 
 	/* Create debounce utilities */
 	for (uint8_t i = 0; i < MAX_STEERING_BUTTONS; i++) {
-		steeringio->debounce_timers[i] = osTimerCreate(osTimer(debounce_timer), osTimerOnce, steeringio);
+		steeringio->debounce_timers[i] = osTimerNew(debounce_cb, osTimerOnce, steeringio, NULL);
 		assert(steeringio->debounce_timers[i]);
 	}
 	steeringio->debounce_buffer = ringbuffer_create(MAX_STEERING_BUTTONS, sizeof(uint8_t));
@@ -63,7 +62,7 @@ bool get_steeringio_button(steeringio_t *wheel, steeringio_button_t button)
 }
 
 /* Callback to see if we have successfully debounced */
-static void debounce_cb(void const *arg)
+static void debounce_cb(void *arg)
 {
 	steeringio_t *wheel = (steeringio_t *)arg;
 	if (!wheel)

--- a/Core/Src/torque.c
+++ b/Core/Src/torque.c
@@ -42,9 +42,9 @@ void vCalcTorque(void* pv_params)
 	pedals_t pedal_data;
 	uint16_t torque = 0;
 	osStatus_t stat;
-	dti_t mc;
 
-	dti_init(&mc);
+	//TODO: Get important data from MC
+	//dti_t *mc = (dti_t *)pv_params;
 
 	for (;;) {
 		stat = osMessageQueueGet(pedal_data_queue, &pedal_data, 0U, delay_time);

--- a/Core/Src/torque.c
+++ b/Core/Src/torque.c
@@ -32,8 +32,8 @@ const osThreadAttr_t torque_calc_attributes = {
 	.priority = (osPriority_t)osPriorityAboveNormal4
 };
 
-void vCalcTorque(void* pv_params) {
-
+void vCalcTorque(void* pv_params)
+{
 	const uint16_t delay_time  = 5; /* ms */
 
 	/* End application if we try to update motor at freq below this value */
@@ -54,7 +54,7 @@ void vCalcTorque(void* pv_params) {
 			// TODO: Add state based torque calculation
 
 			uint16_t accel = pedal_data.accelerator_value;
-			
+
 			if (accel < MIN_PEDAL_VAL)
 				torque = 0;
 			else


### PR DESCRIPTION
## Changes

Changed how CAN routing is working to be queue based rather than callback based. This will simplify the code a bit to not have to deal with a bunch of function pointers and rather just a few queues. This will also allow us to give control back to the scheduler during a particularly long callback if we end up needing it.

## Notes

* I was originally playing around with the idea of using a signal or binary semaphore to signal the routers but instead I opted for just using a Queue for signaling to account for multiple CAN messages coming in at once from the same node.

## To Do

- [x] Steering Wheel Handler

Closes #125 
