### PR TITLE
ADCs work again

### DIFF
--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -176,7 +176,7 @@ int main(void)
   mpu_t *mpu  = init_mpu(&hi2c1, &hadc1, &hadc2, &hadc3, GPIOC, GPIOB);
   pdu_t *pdu  = init_pdu(&hi2c2);
   dti_t *mc   = dti_init();
-  steeringio_t *wheel = steeringio_init();
+  //steeringio_t *wheel = steeringio_init();
   can_t *can1 = init_can1(&hcan1);
 
   /* USER CODE END RTOS_MUTEX */
@@ -211,7 +211,7 @@ int main(void)
   /* Messaging */
   /* Note that CAN Router initializes CAN */
   dti_router_handle = osThreadNew(vDTIRouter, mc, &dti_router_attributes);
-  steeringio_router_handle = osThreadNew(vSteeringIORouter, wheel, &steeringio_router_attributes);
+  //steeringio_router_handle = osThreadNew(vSteeringIORouter, wheel, &steeringio_router_attributes);
   can_dispatch_handle = osThreadNew(vCanDispatch, can1, &can_dispatch_attributes);
   serial_monitor_handle = osThreadNew(vSerialMonitor, NULL, &serial_monitor_attributes);
 

--- a/Core/Src/monitor.c
+++ b/Core/Src/monitor.c
@@ -87,7 +87,7 @@ const osThreadAttr_t pedals_monitor_attributes = {
 
 void vPedalsMonitor(void* pv_params)
 {
-	// const uint8_t num_samples = 10;
+	const uint8_t num_samples = 10;
 	enum { ACCELPIN_1, ACCELPIN_2, BRAKEPIN_1, BRAKEPIN_2 };
 	// nertimer_t diff_timer;
 	// nertimer_t sc_timer;
@@ -95,21 +95,17 @@ void vPedalsMonitor(void* pv_params)
 	static pedals_t sensor_data;
 	fault_data_t fault_data = { .id = ONBOARD_PEDAL_FAULT, .severity = DEFCON1 };
 	can_msg_t pedal_msg		= { .id = CANID_PEDAL_SENSOR, .len = 4, .data = { 0 } };
-	// uint16_t adc_data[3];
+	uint16_t adc_data[3];
 
 	/* Handle ADC Data for two input accelerator value and two input brake value*/
-	// mpu_t *mpu = (mpu_t *)pv_params;
+	mpu_t *mpu = (mpu_t *)pv_params;
 
 	for (;;) {
 		// serial_print("Pedals Task: %d\r\n", HAL_GetTick() - curr_tick);
-		// if (read_adc(mpu, adc_data)) {
-		//	fault_data.diag = "Failed to collect ADC Data!";
-		//	queue_fault(&fault_data);
-		// }
-
-		// err = HAL_ADC_PollForConversion(params->brake_adc, HAL_MAX_DELAY);
-		// if (!err)
-		// serial_print("Brake 2: %d\r\n", HAL_ADC_GetValue(params->brake_adc));
+		if (read_adc(mpu, adc_data)) {
+			fault_data.diag = "Failed to collect ADC Data!";
+			queue_fault(&fault_data);
+		}
 
 		/* Evaluate accelerator faults */
 		// if (is_timer_expired(&oc_timer))
@@ -135,12 +131,13 @@ void vPedalsMonitor(void* pv_params)
 		// MAX_ADC_VAL_12B) && 	!is_timer_active(&diff_timer)) 	start_timer(&diff_timer,
 		// PEDAL_FAULT_TIME); else 	cancel_timer(&diff_timer);
 
-		// sensor_data.acceleratorValue
-		//	= (sensor_data.acceleratorValue + (adc_data[ACCELPIN_1] + adc_data[ACCELPIN_2]) / 2)
-		//	  / num_samples;
-		// sensor_data.brakeValue
-		//	= (sensor_data.brakeValue + (adc_data[BRAKEPIN_1] + adc_data[BRAKEPIN_2]) / 2)
-		//	  / num_samples;
+		/* Low Pass Filter */
+		sensor_data.accelerator_value
+			= (sensor_data.accelerator_value + (adc_data[ACCELPIN_1] + adc_data[ACCELPIN_2]) / 2)
+			  / num_samples;
+		 sensor_data.brake_value
+			= (sensor_data.brake_value + (adc_data[BRAKEPIN_1] + adc_data[BRAKEPIN_2]) / 2)
+			  / num_samples;
 
 		/* Publish to Onboard Pedals Queue */
 		osMessageQueuePut(pedal_data_queue, &sensor_data, 0U, 0U);

--- a/Core/Src/mpu.c
+++ b/Core/Src/mpu.c
@@ -52,7 +52,7 @@ mpu_t* init_mpu(I2C_HandleTypeDef* hi2c, ADC_HandleTypeDef* accel_adc1,
 	mpu->adc_mutex = osMutexNew(&mpu_adc_mutex_attr);
 	assert(mpu->adc_mutex);
 
-	return 0;
+	return mpu;
 }
 
 int8_t write_rled(mpu_t* mpu, bool status)


### PR DESCRIPTION
## Changes

There was a bug where the new interface for retrieving ADC data was not actually returning anything. This PR fixes that

## Notes

The main problem is that in the init function for the mpu struct, we were returning a 0, not the struct allocated. This resulted in a lot of weird behavior, specifically the adc read function immediately failing because it detected that the pointer was NULL

## Test Cases

- It built
- It run on hardware
- Printed out ADC values to confirm we were getting realistic readings
