### PR TITLE
Better can cb

### DIFF
--- a/Core/Inc/can_handler.h
+++ b/Core/Inc/can_handler.h
@@ -17,9 +17,7 @@
 #include "can.h"
 #include "cmsis_os.h"
 
-void vRouteCanIncoming(void* pv_params);
-extern osThreadId_t route_can_incoming_handle;
-extern const osThreadAttr_t route_can_incoming_attributes;
+void can1_callback(CAN_HandleTypeDef* hcan);
 
 void vCanDispatch(void* pv_params);
 extern osThreadId_t can_dispatch_handle;

--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -28,8 +28,6 @@ static uint16_t id_list[] = {
 	DTI_CANID_ID_IQ, DTI_CANID_SIGNALS,	 STEERING_CANID_IO,
 };
 
-void can1_callback(CAN_HandleTypeDef* hcan);
-
 can_t* init_can1(CAN_HandleTypeDef* hcan)
 {
 	assert(hcan);
@@ -39,7 +37,6 @@ can_t* init_can1(CAN_HandleTypeDef* hcan)
 	assert(can1);
 
 	can1->hcan		  = hcan;
-	can1->callback	  = can1_callback;
 	can1->id_list	  = id_list;
 	can1->id_list_len = sizeof(id_list) / sizeof(uint16_t);
 
@@ -47,8 +44,6 @@ can_t* init_can1(CAN_HandleTypeDef* hcan)
 
 	return can1;
 }
-
-
 
 /* Callback to be called when we get a CAN message */
 void can1_callback(CAN_HandleTypeDef* hcan)

--- a/Core/Src/stm32f4xx_it.c
+++ b/Core/Src/stm32f4xx_it.c
@@ -24,8 +24,7 @@
 #include "task.h"
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
-/* USER CODE END Includes */
-
+#include "can_handler.h"
 /* Private typedef -----------------------------------------------------------*/
 /* USER CODE BEGIN TD */
 
@@ -188,7 +187,7 @@ void SysTick_Handler(void)
 void CAN1_RX0_IRQHandler(void)
 {
   /* USER CODE BEGIN CAN1_RX0_IRQn 0 */
-
+  can1_callback(&hcan1);
   /* USER CODE END CAN1_RX0_IRQn 0 */
   HAL_CAN_IRQHandler(&hcan1);
   /* USER CODE BEGIN CAN1_RX0_IRQn 1 */


### PR DESCRIPTION
## Changes

Making CAN callback simpler

## Notes

Using STM32's default method for where to actual put interrupt callback code. This is what we should have been doing all along and makes this so much less complicated.

## Test Cases

- It builds

## To Do

_Any remaining things that need to get done_

- [ ] Test on hardware
