### PR TITLE
clean dti dispatch, make messages correct length

### DIFF
--- a/Core/Inc/dti.h
+++ b/Core/Inc/dti.h
@@ -47,10 +47,10 @@ typedef struct
 uint32_t dti_get_rpm(dti_t* dti);
 
 /* Utilities for Decoding CAN message */
-extern osThreadId_t dti_router_handle;
-extern const osThreadAttr_t dti_router_attributes;
-extern osMessageQueueId_t dti_router_queue;
-void vDTIRouter(void* pv_params);
+// extern osThreadId_t dti_router_handle;
+// extern const osThreadAttr_t dti_router_attributes;
+// extern osMessageQueueId_t dti_router_queue;
+// void vDTIRouter(void* pv_params);
 
 dti_t* dti_init();
 

--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -78,9 +78,9 @@ void can1_callback(CAN_HandleTypeDef* hcan)
 	case DTI_CANID_CURRENTS:
 	case DTI_CANID_TEMPS_FAULT:
 	case DTI_CANID_ID_IQ:
-	case DTI_CANID_SIGNALS:
-		osMessageQueuePut(dti_router_queue, &new_msg, 0U, 0U);
-		break;
+	// case DTI_CANID_SIGNALS:
+	// 	osMessageQueuePut(dti_router_queue, &new_msg, 0U, 0U);
+	// 	break;
 	case BMS_CANID:
 		osMessageQueuePut(bms_monitor_queue, &new_msg, 0U, 0U);
 	default:

--- a/Core/Src/dti.c
+++ b/Core/Src/dti.c
@@ -22,7 +22,7 @@
 #define CAN_QUEUE_SIZE 5 /* messages */
 #define SAMPLES 20
 static osMutexAttr_t dti_mutex_attributes;
-osMessageQueueId_t dti_router_queue;
+// osMessageQueueId_t dti_router_queue;
 
 dti_t* dti_init()
 {
@@ -40,8 +40,8 @@ dti_t* dti_init()
 	// dti_set_max_dc_current();
 
 	/* Create Queue for CAN signaling */
-	dti_router_queue = osMessageQueueNew(CAN_QUEUE_SIZE, sizeof(can_msg_t), NULL);
-	assert(dti_router_queue);
+	// dti_router_queue = osMessageQueueNew(CAN_QUEUE_SIZE, sizeof(can_msg_t), NULL);
+	// assert(dti_router_queue);
 
 	return mc;
 }
@@ -82,7 +82,7 @@ void dti_set_torque(int16_t torque)
 
 void dti_set_current(int16_t current)
 {
-	can_msg_t msg = { .id = 0x036, .len = 8, .data = { 0 } };
+	can_msg_t msg = { .id = 0x036, .len = 2, .data = { 0 } };
 	dti_set_drive_enable(true);
 	/* Send CAN message in big endian format */
 
@@ -193,7 +193,7 @@ void dti_set_max_dc_brake_current(int16_t current)
 
 void dti_set_drive_enable(bool drive_enable)
 {
-	can_msg_t msg = { .id = 0x196, .len = 8, .data = { 0 } };
+	can_msg_t msg = { .id = 0x196, .len = 1, .data = { 0 } };
 
 	/* Send CAN message */
 	memcpy(msg.data, &drive_enable, msg.len);
@@ -211,55 +211,55 @@ uint32_t dti_get_rpm(dti_t* mc)
 }
 
 /* Inbound Task-specific Info */
-osThreadId_t dti_router_handle;
-const osThreadAttr_t dti_router_attributes
-	= { .name = "DTIRouter", .stack_size = 64 * 8, .priority = (osPriority_t)osPriorityHigh };
+// osThreadId_t dti_router_handle;
+// const osThreadAttr_t dti_router_attributes
+// 	= { .name = "DTIRouter", .stack_size = 64 * 8, .priority = (osPriority_t)osPriorityHigh };
 
-static void dti_set_rpm(dti_t *mc, can_msg_t msg)
-{
-	/* ERPM is first four bytes of can message in big endian format */
-	uint32_t erpm = 0;
-	for (int i = 0; i < 4; i++) {
-		erpm |= msg.data[i] << (8 * (3 - i));
-	}
+// static void dti_set_rpm(dti_t *mc, can_msg_t msg)
+// {
+// 	/* ERPM is first four bytes of can message in big endian format */
+// 	uint32_t erpm = 0;
+// 	for (int i = 0; i < 4; i++) {
+// 		erpm |= msg.data[i] << (8 * (3 - i));
+// 	}
 
-	uint32_t rpm = erpm / POLE_PAIRS;
+// 	uint32_t rpm = erpm / POLE_PAIRS;
 
-	osMutexAcquire(*mc->mutex, osWaitForever);
-	mc->rpm = rpm;
-	osMutexRelease(*mc->mutex);
-}
+// 	osMutexAcquire(*mc->mutex, osWaitForever);
+// 	mc->rpm = rpm;
+// 	osMutexRelease(*mc->mutex);
+// }
 
-void vDTIRouter(void* pv_params)
-{
-	can_msg_t message;
-	osStatus_t status;
-	// fault_data_t fault_data = { .id = DTI_ROUTING_FAULT, .severity = DEFCON2 };
+// void vDTIRouter(void* pv_params)
+// {
+// 	can_msg_t message;
+// 	osStatus_t status;
+// 	// fault_data_t fault_data = { .id = DTI_ROUTING_FAULT, .severity = DEFCON2 };
 
-	dti_t *mc = (dti_t *)pv_params;
+// 	dti_t *mc = (dti_t *)pv_params;
 
-	for (;;) {
-		/* Wait until new CAN message comes into queue */
-		status = osMessageQueueGet(dti_router_queue, &message, NULL, osWaitForever);
-		if (status == osOK) 
-		{
-			switch (message.id) 
-			{
-				case DTI_CANID_ERPM:
-					dti_set_rpm(mc, message);
-					break;
-				case DTI_CANID_CURRENTS:
-					break;
-				case DTI_CANID_TEMPS_FAULT:
-					break;
-				case DTI_CANID_ID_IQ:
-					break;
-				case DTI_CANID_SIGNALS:
-					break;
-				default:
-					break;
-			}
-		}
-	}
-}
+// 	for (;;) {
+// 		/* Wait until new CAN message comes into queue */
+// 		status = osMessageQueueGet(dti_router_queue, &message, NULL, osWaitForever);
+// 		if (status == osOK) 
+// 		{
+// 			switch (message.id) 
+// 			{
+// 				case DTI_CANID_ERPM:
+// 					dti_set_rpm(mc, message);
+// 					break;
+// 				case DTI_CANID_CURRENTS:
+// 					break;
+// 				case DTI_CANID_TEMPS_FAULT:
+// 					break;
+// 				case DTI_CANID_ID_IQ:
+// 					break;
+// 				case DTI_CANID_SIGNALS:
+// 					break;
+// 				default:
+// 					break;
+// 			}
+// 		}
+// 	}
+// }
 

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -218,8 +218,8 @@ int main(void)
   assert(shutdown_monitor_handle);
 
   /* Messaging */
-  dti_router_handle = osThreadNew(vDTIRouter, mc, &dti_router_attributes);
-  assert(dti_router_handle);
+  //dti_router_handle = osThreadNew(vDTIRouter, mc, &dti_router_attributes);
+  //assert(dti_router_handle);
   can_dispatch_handle = osThreadNew(vCanDispatch, can1, &can_dispatch_attributes);
   assert(can_dispatch_handle);
   bms_monitor_handle = osThreadNew(vBMSCANMonitor, bms, &bms_monitor_attributes);

--- a/Core/Src/nero.c
+++ b/Core/Src/nero.c
@@ -9,7 +9,7 @@
 #include "monitor.h"
 static nero_state_t nero_state = { .nero_index = 0, .home_mode = true};
 static void send_mode_status() {
-	can_msg_t msg = { .id = 0x501, .len = 8, .data = { nero_state.home_mode, nero_state.nero_index, 0, 0, 0, 0, 0, 0 } };
+	can_msg_t msg = { .id = 0x501, .len = 2, .data = { nero_state.home_mode, nero_state.nero_index} };
 	/* Send CAN message */
 	queue_can_msg(msg);
 }


### PR DESCRIPTION
Get rid of can dispatch.

Set messages back to correct length.