### PR TITLE
Fixes for RTOS debouncing

### DIFF
--- a/Core/Inc/cerberus_conf.h
+++ b/Core/Inc/cerberus_conf.h
@@ -23,7 +23,10 @@
 /* Torque Tuning */
 #define MAX_TORQUE              200 /* Nm * 10 */
 
-#define STEERING_WHEEL_DEBOUNCE 25  /* ms */
+// DEBUGGING: Start with a high debounce period, lower it if it is too slow
+// NOTE: SteeringIOMonitor updates every 25 ms. Previous value of 25 ms doesn't
+// give enough time to differentiate signal from noise.
+#define STEERING_WHEEL_DEBOUNCE 100  /* ms */
 
 /* Pin Assignments */
 #define FAULT_MCU_Pin		GPIO_PIN_3

--- a/Core/Src/steeringio.c
+++ b/Core/Src/steeringio.c
@@ -71,6 +71,18 @@ bool get_steeringio_button(steeringio_t* wheel, steeringio_button_t button)
 	return ret;
 }
 
+static void paddle_left_cb() {
+	if (get_drive_state() == ENDURANCE) {
+		increase_torque_limit();
+	}
+}
+
+static void paddle_right_cb() {
+	if (get_drive_state() == ENDURANCE) {
+		decrease_torque_limit();
+	}
+}
+
 /* Callback to see if we have successfully debounced */
 static void debounce_cb(void* arg)
 {
@@ -85,7 +97,7 @@ static void debounce_cb(void* arg)
 
 	steeringio_t *wheel = args->wheel;
 
-	if (wheel->raw_buttons[button])
+	if (wheel->raw_buttons[button]) {
 		serial_print("%d index pressed \r\n",button);
 		switch (button) {
 			case STEERING_PADDLE_LEFT:
@@ -119,17 +131,6 @@ static void debounce_cb(void* arg)
 			default:
 				break;
 		}
-}
-
-static void paddle_left_cb() {
-	if (get_drive_state() == ENDURANCE) {
-		increase_torque_limit();
-	}
-}
-
-static void paddle_right_cb() {
-	if (get_drive_state() == ENDURANCE) {
-		decrease_torque_limit();
 	}
 }
 


### PR DESCRIPTION
## Changes

- Higher time for a button to be pressed
- Button press behavior is called in cb rather than update
- Timer is stopped if a button has stopped being pressed while we are debouncing the input
- 
## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please reach out to your Project Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
