### PR TITLE
Changing from passing in references of structs to global references

### DIFF
--- a/Core/Src/pdu.c
+++ b/Core/Src/pdu.c
@@ -354,7 +354,7 @@ int8_t read_shutdown(pdu_t* pdu, shutdown_stage_t stage, bool* status)
 	return 0;
 }
 
-int8_t write_rtds(pdu_t* pdu, bool status) 
+int8_t write_rtds(pdu_t* pdu, bool status)
 {
     if (!pdu)
 		return -1;

--- a/Core/Src/torque.c
+++ b/Core/Src/torque.c
@@ -29,6 +29,8 @@
 #define MIN_COMMAND_FREQ  60					  /* Hz */
 #define MAX_COMMAND_DELAY 1000 / MIN_COMMAND_FREQ /* ms */
 
+extern dti_t *mc;
+
 static float torque_limit_percentage = 1.0;
 
 osThreadId_t torque_calc_handle;
@@ -113,8 +115,6 @@ void vCalcTorque(void* pv_params)
 	pedals_t pedal_data;
 	uint16_t torque = 0;
 	osStatus_t stat;
-
-	dti_t *mc = (dti_t *)pv_params;
 
 	for (;;) {
 		stat = osMessageQueueGet(pedal_data_queue, &pedal_data, 0U, delay_time);


### PR DESCRIPTION
## Changes

Title kinda says it all. Even if we are passing pointers, the pointers themselves still take up 32 bits on their own. This should reduce the stack size of each task in that they don't have their won personal reference and are just pointing to the global ones. Less scalable but we've seen that this is probably the largest scale that Cerberus will be for a while.

## Notes

Pretty much untested on the car, does build

## To Do

_Any remaining things that need to get done_

- [ ] Make sure it runs on car
- [ ] Try and reduce the stack size of tasks to account for this change
