### PR TITLE
whoho blinky

### DIFF
--- a/Core/Src/stm32f4xx_it.c
+++ b/Core/Src/stm32f4xx_it.c
@@ -92,6 +92,18 @@ void HardFault_Handler(void)
   while (1)
   {
     /* USER CODE BEGIN W1_HardFault_IRQn 0 */
+    volatile uint32_t i = 0;
+    while (i < 120000) {
+      i += 1;
+    }
+    HAL_GPIO_WritePin(GPIOC, GPIO_PIN_9, 0);
+    HAL_GPIO_WritePin(GPIOC, GPIO_PIN_8, 0);
+    i = 0;
+    while (i < 120000) {
+      i += 1;
+    }
+    HAL_GPIO_WritePin(GPIOC, GPIO_PIN_9, 1);
+    HAL_GPIO_WritePin(GPIOC, GPIO_PIN_8, 1);
     /* USER CODE END W1_HardFault_IRQn 0 */
   }
 }


### PR DESCRIPTION
Hardfault go blinky.

Rationale: 
HardFault handler is an ISR, of which running code inside has absolutely no gaurrantees any memory is intact.  I tried printf. hal and os delays, etc. and anything interrupt based or using internal interrupt hardware or buffers is disabled or tainted.  
Turns out though, GPIO write still works lol. Probably due to the simplicity.  Since there is no osDelay, busy poll the CPU with a volatile uint.

https://github.com/user-attachments/assets/3f61584f-2865-456b-a34c-01056627e97a


