### PR TITLE
Added LV Sense SoC to CAN

### DIFF
--- a/Core/Src/monitor.c
+++ b/Core/Src/monitor.c
@@ -77,8 +77,8 @@ void read_lv_sense(void *arg)
 	lv_data.v = v_int;
 	lv_data.soc = soc_int;
 
-	memcpy(msg.data, &lv_data, msg.len);
-	if (queue_can_msg(msg)) {
+	memcpy(lv_msg.data, &lv_data, lv_msg.len);
+	if (queue_can_msg(lv_msg)) {
 		fault_data.diag =
 			"Failed to send steering LV monitor CAN message";
 		queue_fault(&fault_data);

--- a/Core/Src/monitor.c
+++ b/Core/Src/monitor.c
@@ -77,7 +77,7 @@ void read_lv_sense(void *arg)
 	lv_data.v = v_int;
 	lv_data.soc = soc_int;
 
-	memcpy(msg.data, &v_int, msg.len);
+	memcpy(msg.data, &lv_data, msg.len);
 	if (queue_can_msg(msg)) {
 		fault_data.diag =
 			"Failed to send steering LV monitor CAN message";

--- a/Core/Src/monitor.c
+++ b/Core/Src/monitor.c
@@ -35,14 +35,14 @@ void read_lv_sense(void *arg)
 	mpu_t *mpu = (mpu_t *)arg;
 	fault_data_t fault_data = { .id = LV_MONITOR_FAULT,
 				    .severity = DEFCON5 };
-	can_msg_t msg = { .id = CANID_LV_MONITOR, .len = 8, .data = { 0 } };
+	can_msg_t lv_msg = { .id = CANID_LV_MONITOR, .len = 5, .data = { 0 } };
 
 	uint32_t v_int;
 	uint32_t soc_int;
 
 	struct __attribute__((__packed__)) {
 		uint32_t v;
-		uint32_t soc;
+		uint8_t soc;
 	} lv_data;
 
 	read_lv_voltage(mpu, &v_int);
@@ -65,9 +65,9 @@ void read_lv_sense(void *arg)
 	// - Divide v_dec by 7 to get avg voltage over all rows
 	// - Use logistic function to model SoC
 	// https://www.aegisbattery.com/products/24v-20ah-li-ion-battery-pvc
-	float v_max = 4.2; // max avg voltage over all rows (7)
-	float v_min = 2.8; // min avg voltage over all rows (7)
-	float k = -8.5; // logistic fn parameter to affect steepness of curve
+	static const float v_max = 4.2; // max avg voltage over all rows (7)
+	static const float v_min = 2.8; // min avg voltage over all rows (7)
+	static const float k = -8.5; // logistic fn parameter to affect steepness of curve
 	float i = (v_max + v_min) /
 		  2; // logistic fn parameter to affect midpoint of curve
 	float soc_dec =

--- a/Core/Src/monitor.c
+++ b/Core/Src/monitor.c
@@ -67,7 +67,8 @@ void read_lv_sense(void *arg)
 	// https://www.aegisbattery.com/products/24v-20ah-li-ion-battery-pvc
 	static const float v_max = 4.2; // max avg voltage over all rows (7)
 	static const float v_min = 2.8; // min avg voltage over all rows (7)
-	static const float k = -8.5; // logistic fn parameter to affect steepness of curve
+	static const float k =
+		-8.5; // logistic fn parameter to affect steepness of curve
 	float i = (v_max + v_min) /
 		  2; // logistic fn parameter to affect midpoint of curve
 	float soc_dec =

--- a/Core/Src/monitor.c
+++ b/Core/Src/monitor.c
@@ -38,12 +38,12 @@ void read_lv_sense(void *arg)
 	can_msg_t msg = { .id = CANID_LV_MONITOR, .len = 8, .data = { 0 } };
 
 	uint32_t v_int;
-  uint32_t soc_int;
+	uint32_t soc_int;
 
-  struct __attribute__((__packed__)) {
-    uint32_t v;
-    uint32_t soc;
-  } lv_data;
+	struct __attribute__((__packed__)) {
+		uint32_t v;
+		uint32_t soc;
+	} lv_data;
 
 	read_lv_voltage(mpu, &v_int);
 
@@ -68,12 +68,14 @@ void read_lv_sense(void *arg)
 	float v_max = 4.2; // max avg voltage over all rows (7)
 	float v_min = 2.8; // min avg voltage over all rows (7)
 	float k = -8.5; // logistic fn parameter to affect steepness of curve
-	float i = (v_max + v_min) / 2; // logistic fn parameter to affect midpoint of curve
-	float soc_dec = 1 / (1 + exp(k * (v_dec - i))); // SoC calculation in [0,1]
+	float i = (v_max + v_min) /
+		  2; // logistic fn parameter to affect midpoint of curve
+	float soc_dec =
+		1 / (1 + exp(k * (v_dec - i))); // SoC calculation in [0,1]
 	soc_int = soc_dec * 100;
 
-  lv_data.v = v_int;
-  lv_data.soc = soc_int;
+	lv_data.v = v_int;
+	lv_data.soc = soc_int;
 
 	memcpy(msg.data, &v_int, msg.len);
 	if (queue_can_msg(msg)) {

--- a/Core/Src/monitor.c
+++ b/Core/Src/monitor.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <math.h>
 
 #define TSMS_DEBOUNCE_PERIOD 500 /* ms */
 
@@ -34,9 +35,15 @@ void read_lv_sense(void *arg)
 	mpu_t *mpu = (mpu_t *)arg;
 	fault_data_t fault_data = { .id = LV_MONITOR_FAULT,
 				    .severity = DEFCON5 };
-	can_msg_t msg = { .id = CANID_LV_MONITOR, .len = 4, .data = { 0 } };
+	can_msg_t msg = { .id = CANID_LV_MONITOR, .len = 8, .data = { 0 } };
 
 	uint32_t v_int;
+  uint32_t soc_int;
+
+  struct __attribute__((__packed__)) {
+    uint32_t v;
+    uint32_t soc;
+  } lv_data;
 
 	read_lv_voltage(mpu, &v_int);
 
@@ -50,6 +57,23 @@ void read_lv_sense(void *arg)
 
 	// get final voltage
 	v_int = (uint32_t)(v_dec * 10.0);
+
+	// Calculate SoC using logistic function
+	// - Normal charged voltage is 29.4V
+	// - 18650 max charged voltage is 4.2V
+	// - 29.4V/4.2V = 7 batteries
+	// - Divide v_dec by 7 to get avg voltage over all rows
+	// - Use logistic function to model SoC
+	// https://www.aegisbattery.com/products/24v-20ah-li-ion-battery-pvc
+	float v_max = 4.2; // max avg voltage over all rows (7)
+	float v_min = 2.8; // min avg voltage over all rows (7)
+	float k = -8.5; // logistic fn parameter to affect steepness of curve
+	float i = (v_max + v_min) / 2; // logistic fn parameter to affect midpoint of curve
+	float soc_dec = 1 / (1 + exp(k * (v_dec - i))); // SoC calculation in [0,1]
+	soc_int = soc_dec * 100;
+
+  lv_data.v = v_int;
+  lv_data.soc = soc_int;
 
 	memcpy(msg.data, &v_int, msg.len);
 	if (queue_can_msg(msg)) {


### PR DESCRIPTION
## Changes

- Added LV Sense SoC calculation using logistic function to `Core/Src/monitor.c`
- Added `#include <math.h>` to `Core/Src/monitor.c`
- Changed CAN spec in `mpu.json` to include SOC NetField in `0x503` (See https://github.com/Northeastern-Electric-Racing/Embedded-Base/pull/212)

Closes #219 
