### PR TITLE
comment out lsm, sht30 (untested)

### DIFF
--- a/Core/Inc/monitor.h
+++ b/Core/Inc/monitor.h
@@ -49,9 +49,9 @@ extern const osThreadAttr_t data_collection_attributes;
  * -------------------------------------------------------------------------------------------------------*/
 
 /* Task for Monitoring the IMU */
-void vIMUMonitor(void *pv_params);
-extern osThreadId_t imu_monitor_handle;
-extern const osThreadAttr_t imu_monitor_attributes;
+// void vIMUMonitor(void *pv_params);
+// extern osThreadId_t imu_monitor_handle;
+// extern const osThreadAttr_t imu_monitor_attributes;
 
 /* Task for Monitoring the Shutdown Loop */
 void vShutdownMonitor(void *pv_params);
@@ -59,8 +59,8 @@ extern osThreadId_t shutdown_monitor_handle;
 extern const osThreadAttr_t shutdown_monitor_attributes;
 
 /* Defining Temperature Monitor Task */
-void vTempMonitor(void *pv_params);
-extern osThreadId_t temp_monitor_handle;
-extern const osThreadAttr_t temp_monitor_attributes;
+// void vTempMonitor(void *pv_params);
+// extern osThreadId_t temp_monitor_handle;
+// extern const osThreadAttr_t temp_monitor_attributes;
 
 #endif // MONITOR_H

--- a/Core/Inc/mpu.h
+++ b/Core/Inc/mpu.h
@@ -1,10 +1,8 @@
 #ifndef MPU_H
 #define MPU_H
 
-#include "cmsis_os.h"
-#include "lsm6dso.h"
-#include "sht30.h"
-#include "stm32f405xx.h"
+#include "cmsis_os2.h"
+#include "stm32f4xx_hal.h"
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -18,8 +16,8 @@ typedef struct {
 
 	GPIO_TypeDef *led_gpio;
 	GPIO_TypeDef *watchdog_gpio;
-	sht30_t *temp_sensor;
-	lsm6dso_t *imu;
+	// sht30_t *temp_sensor;
+	// lsm6dso_t *imu;
 	osMutexId_t *adc_mutex;
 	osMutexId_t *i2c_mutex;
 	/* Not including LED Mutexes because not necessary */
@@ -71,10 +69,10 @@ int8_t toggle_yled(mpu_t *mpu);
 
 int8_t pet_watchdog(mpu_t *mpu);
 
-int8_t read_temp_sensor(mpu_t *mpu, uint16_t *temp, uint16_t *humidity);
+// int8_t read_temp_sensor(mpu_t *mpu, uint16_t *temp, uint16_t *humidity);
 
-int8_t read_accel(mpu_t *mpu);
+// int8_t read_accel(mpu_t *mpu);
 
-int8_t read_gyro(mpu_t *mpu);
+// int8_t read_gyro(mpu_t *mpu);
 
 #endif /* MPU */

--- a/Core/Src/monitor.c
+++ b/Core/Src/monitor.c
@@ -4,7 +4,7 @@
 #include "cerb_utils.h"
 #include "cerberus_conf.h"
 #include "fault.h"
-#include "lsm6dso.h"
+// #include "lsm6dso.h"
 #include "mpu.h"
 #include "pdu.h"
 #include "pedals.h"
@@ -15,7 +15,6 @@
 #include "stm32f405xx.h"
 #include "task.h"
 #include "timer.h"
-#include <lsm6dso.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -202,49 +201,49 @@ void vDataCollection(void *pv_params)
 
 /* Unused -----------------------------------------------*/
 
-osThreadId_t temp_monitor_handle;
-const osThreadAttr_t temp_monitor_attributes = {
-	.name = "TempMonitor",
-	.stack_size = 32 * 8,
-	.priority = (osPriority_t)osPriorityHigh1,
-};
+// osThreadId_t temp_monitor_handle;
+// const osThreadAttr_t temp_monitor_attributes = {
+// 	.name = "TempMonitor",
+// 	.stack_size = 32 * 8,
+// 	.priority = (osPriority_t)osPriorityHigh1,
+// };
 
-void vTempMonitor(void *pv_params)
-{
-	fault_data_t fault_data = { .id = ONBOARD_TEMP_FAULT,
-				    .severity = DEFCON5 };
-	can_msg_t temp_msg = { .id = CANID_TEMP_SENSOR,
-			       .len = 4,
-			       .data = { 0 } };
+// void vTempMonitor(void *pv_params)
+// {
+// 	fault_data_t fault_data = { .id = ONBOARD_TEMP_FAULT,
+// 				    .severity = DEFCON5 };
+// 	can_msg_t temp_msg = { .id = CANID_TEMP_SENSOR,
+// 			       .len = 4,
+// 			       .data = { 0 } };
 
-	mpu_t *mpu = (mpu_t *)pv_params;
+// 	mpu_t *mpu = (mpu_t *)pv_params;
 
-	for (;;) {
-		/* Take measurement */
-		uint16_t temp = 0;
-		uint16_t humidity = 0;
-		if (read_temp_sensor(mpu, &temp, &humidity)) {
-			fault_data.diag = "Failed to get temp";
-			queue_fault(&fault_data);
-		}
+// 	for (;;) {
+// 		/* Take measurement */
+// 		uint16_t temp = 0;
+// 		uint16_t humidity = 0;
+// 		if (read_temp_sensor(mpu, &temp, &humidity)) {
+// 			fault_data.diag = "Failed to get temp";
+// 			queue_fault(&fault_data);
+// 		}
 
-		printf("MPU Board Temperature:\t%d\n", temp);
+// 		printf("MPU Board Temperature:\t%d\n", temp);
 
-		temp_msg.data[0] = temp & 0xFF;
-		temp_msg.data[1] = (temp >> 8) & 0xFF;
-		temp_msg.data[2] = humidity & 0xFF;
-		temp_msg.data[3] = (humidity >> 8) & 0xFF;
+// 		temp_msg.data[0] = temp & 0xFF;
+// 		temp_msg.data[1] = (temp >> 8) & 0xFF;
+// 		temp_msg.data[2] = humidity & 0xFF;
+// 		temp_msg.data[3] = (humidity >> 8) & 0xFF;
 
-		/* Send CAN message */
-		if (queue_can_msg(temp_msg)) {
-			fault_data.diag = "Failed to send CAN message";
-			queue_fault(&fault_data);
-		}
+// 		/* Send CAN message */
+// 		if (queue_can_msg(temp_msg)) {
+// 			fault_data.diag = "Failed to send CAN message";
+// 			queue_fault(&fault_data);
+// 		}
 
-		/* Yield to other tasks */
-		osDelay(TEMP_SENS_SAMPLE_DELAY);
-	}
-}
+// 		/* Yield to other tasks */
+// 		osDelay(TEMP_SENS_SAMPLE_DELAY);
+// 	}
+// }
 
 osThreadId_t shutdown_monitor_handle;
 const osThreadAttr_t shutdown_monitor_attributes = {
@@ -302,85 +301,85 @@ void vShutdownMonitor(void *pv_params)
 	}
 }
 
-osThreadId_t imu_monitor_handle;
-const osThreadAttr_t imu_monitor_attributes = {
-	.name = "IMUMonitor",
-	.stack_size = 32 * 8,
-	.priority = (osPriority_t)osPriorityHigh,
-};
+// osThreadId_t imu_monitor_handle;
+// const osThreadAttr_t imu_monitor_attributes = {
+// 	.name = "IMUMonitor",
+// 	.stack_size = 32 * 8,
+// 	.priority = (osPriority_t)osPriorityHigh,
+// };
 
-void vIMUMonitor(void *pv_params)
-{
-	const uint8_t num_samples = 10;
-	static imu_data_t sensor_data;
-	fault_data_t fault_data = { .id = IMU_FAULT, .severity = DEFCON5 };
-	can_msg_t imu_accel_msg = { .id = CANID_IMU_ACCEL,
-				    .len = 6,
-				    .data = { 0 } };
-	can_msg_t imu_gyro_msg = { .id = CANID_IMU_GYRO,
-				   .len = 6,
-				   .data = { 0 } };
+// void vIMUMonitor(void *pv_params)
+// {
+// 	const uint8_t num_samples = 10;
+// 	static imu_data_t sensor_data;
+// 	fault_data_t fault_data = { .id = IMU_FAULT, .severity = DEFCON5 };
+// 	can_msg_t imu_accel_msg = { .id = CANID_IMU_ACCEL,
+// 				    .len = 6,
+// 				    .data = { 0 } };
+// 	can_msg_t imu_gyro_msg = { .id = CANID_IMU_GYRO,
+// 				   .len = 6,
+// 				   .data = { 0 } };
 
-	mpu_t *mpu = (mpu_t *)pv_params;
+// 	mpu_t *mpu = (mpu_t *)pv_params;
 
-	for (;;) {
-		// printf("IMU Task\r\n");
-		/* Take measurement */
-		if (read_accel(mpu)) {
-			fault_data.diag = "Failed to get IMU acceleration";
-			queue_fault(&fault_data);
-		}
+// 	for (;;) {
+// 		// printf("IMU Task\r\n");
+// 		/* Take measurement */
+// 		if (read_accel(mpu)) {
+// 			fault_data.diag = "Failed to get IMU acceleration";
+// 			queue_fault(&fault_data);
+// 		}
 
-		if (read_gyro(mpu)) {
-			fault_data.diag = "Failed to get IMU gyroscope";
-			queue_fault(&fault_data);
-		}
+// 		if (read_gyro(mpu)) {
+// 			fault_data.diag = "Failed to get IMU gyroscope";
+// 			queue_fault(&fault_data);
+// 		}
 
-		/* Run values through LPF of sample size  */
-		sensor_data.accel_x =
-			(sensor_data.accel_x + mpu->imu->accel_data[0]) /
-			num_samples;
-		sensor_data.accel_y =
-			(sensor_data.accel_y + mpu->imu->accel_data[1]) /
-			num_samples;
-		sensor_data.accel_z =
-			(sensor_data.accel_z + mpu->imu->accel_data[2]) /
-			num_samples;
-		sensor_data.gyro_x =
-			(sensor_data.gyro_x + mpu->imu->gyro_data[0]) /
-			num_samples;
-		sensor_data.gyro_y =
-			(sensor_data.gyro_y + mpu->imu->gyro_data[1]) /
-			num_samples;
-		sensor_data.gyro_z =
-			(sensor_data.gyro_z + mpu->imu->gyro_data[2]) /
-			num_samples;
+// 		/* Run values through LPF of sample size  */
+// 		sensor_data.accel_x =
+// 			(sensor_data.accel_x + mpu->imu->accel_data[0]) /
+// 			num_samples;
+// 		sensor_data.accel_y =
+// 			(sensor_data.accel_y + mpu->imu->accel_data[1]) /
+// 			num_samples;
+// 		sensor_data.accel_z =
+// 			(sensor_data.accel_z + mpu->imu->accel_data[2]) /
+// 			num_samples;
+// 		sensor_data.gyro_x =
+// 			(sensor_data.gyro_x + mpu->imu->gyro_data[0]) /
+// 			num_samples;
+// 		sensor_data.gyro_y =
+// 			(sensor_data.gyro_y + mpu->imu->gyro_data[1]) /
+// 			num_samples;
+// 		sensor_data.gyro_z =
+// 			(sensor_data.gyro_z + mpu->imu->gyro_data[2]) /
+// 			num_samples;
 
-		/* Publish to IMU Queue */
-		osMessageQueuePut(imu_queue, &sensor_data, 0U, 0U);
+// 		/* Publish to IMU Queue */
+// 		osMessageQueuePut(imu_queue, &sensor_data, 0U, 0U);
 
-		/* convert to big endian */
-		endian_swap(&sensor_data.accel_x, sizeof(sensor_data.accel_x));
-		endian_swap(&sensor_data.accel_y, sizeof(sensor_data.accel_y));
-		endian_swap(&sensor_data.accel_z, sizeof(sensor_data.accel_z));
-		endian_swap(&sensor_data.gyro_x, sizeof(sensor_data.gyro_x));
-		endian_swap(&sensor_data.gyro_y, sizeof(sensor_data.gyro_y));
-		endian_swap(&sensor_data.gyro_z, sizeof(sensor_data.gyro_z));
+// 		/* convert to big endian */
+// 		endian_swap(&sensor_data.accel_x, sizeof(sensor_data.accel_x));
+// 		endian_swap(&sensor_data.accel_y, sizeof(sensor_data.accel_y));
+// 		endian_swap(&sensor_data.accel_z, sizeof(sensor_data.accel_z));
+// 		endian_swap(&sensor_data.gyro_x, sizeof(sensor_data.gyro_x));
+// 		endian_swap(&sensor_data.gyro_y, sizeof(sensor_data.gyro_y));
+// 		endian_swap(&sensor_data.gyro_z, sizeof(sensor_data.gyro_z));
 
-		/* Send CAN message */
-		memcpy(imu_accel_msg.data, &sensor_data, imu_accel_msg.len);
-		// if (queue_can_msg(imu_accel_msg)) {
-		//	fault_data.diag = "Failed to send CAN message";
-		//	queue_fault(&fault_data);
-		// }
+// 		/* Send CAN message */
+// 		memcpy(imu_accel_msg.data, &sensor_data, imu_accel_msg.len);
+// 		// if (queue_can_msg(imu_accel_msg)) {
+// 		//	fault_data.diag = "Failed to send CAN message";
+// 		//	queue_fault(&fault_data);
+// 		// }
 
-		memcpy(imu_gyro_msg.data, &sensor_data, imu_gyro_msg.len);
-		if (queue_can_msg(imu_gyro_msg)) {
-			fault_data.diag = "Failed to send CAN message";
-			queue_fault(&fault_data);
-		}
+// 		memcpy(imu_gyro_msg.data, &sensor_data, imu_gyro_msg.len);
+// 		if (queue_can_msg(imu_gyro_msg)) {
+// 			fault_data.diag = "Failed to send CAN message";
+// 			queue_fault(&fault_data);
+// 		}
 
-		/* Yield to other tasks */
-		osDelay(IMU_SAMPLE_DELAY);
-	}
-}
+// 		/* Yield to other tasks */
+// 		osDelay(IMU_SAMPLE_DELAY);
+// 	}
+// }

--- a/Core/Src/mpu.c
+++ b/Core/Src/mpu.c
@@ -16,19 +16,19 @@ static osMutexAttr_t mpu_i2c_mutex_attr;
 static osMutexAttr_t mpu_adc_mutex_attr;
 I2C_HandleTypeDef *hi2c;
 
-static inline int read_reg(uint8_t *data, uint8_t reg, uint8_t length)
-{
-	return HAL_I2C_Mem_Read(hi2c, LSM6DSO_I2C_ADDRESS, reg,
-				I2C_MEMADD_SIZE_8BIT, data, length,
-				HAL_MAX_DELAY);
-}
+// static inline int read_reg(uint8_t *data, uint8_t reg, uint8_t length)
+// {
+// 	return HAL_I2C_Mem_Read(hi2c, LSM6DSO_I2C_ADDRESS, reg,
+// 				I2C_MEMADD_SIZE_8BIT, data, length,
+// 				HAL_MAX_DELAY);
+// }
 
-static inline int write_reg(uint8_t *data, uint8_t reg, uint8_t length)
-{
-	return HAL_I2C_Mem_Write(hi2c, LSM6DSO_I2C_ADDRESS, reg,
-				 I2C_MEMADD_SIZE_8BIT, data, length,
-				 HAL_MAX_DELAY);
-}
+// static inline int write_reg(uint8_t *data, uint8_t reg, uint8_t length)
+// {
+// 	return HAL_I2C_Mem_Write(hi2c, LSM6DSO_I2C_ADDRESS, reg,
+// 				 I2C_MEMADD_SIZE_8BIT, data, length,
+// 				 HAL_MAX_DELAY);
+// }
 
 mpu_t *init_mpu(ADC_HandleTypeDef *pedals_adc, ADC_HandleTypeDef *lv_adc,
 		GPIO_TypeDef *led_gpio, GPIO_TypeDef *watchdog_gpio)
@@ -49,10 +49,10 @@ mpu_t *init_mpu(ADC_HandleTypeDef *pedals_adc, ADC_HandleTypeDef *lv_adc,
 	mpu->watchdog_gpio = watchdog_gpio;
 
 	/* Initialize the Onboard Temperature Sensor */
-	mpu->temp_sensor = malloc(sizeof(sht30_t));
-	assert(mpu->temp_sensor);
-	mpu->temp_sensor->i2c_handle = hi2c;
-	assert(!sht30_init(mpu->temp_sensor)); /* This is always connected */
+	// mpu->temp_sensor = malloc(sizeof(sht30_t));
+	// assert(mpu->temp_sensor);
+	// mpu->temp_sensor->i2c_handle = hi2c;
+	// assert(!sht30_init(mpu->temp_sensor)); /* This is always connected */
 
 	assert(!HAL_ADC_Start_DMA(mpu->pedals_adc, mpu->pedal_dma_buf,
 				  sizeof(mpu->pedal_dma_buf) /
@@ -135,56 +135,56 @@ void read_pedals(mpu_t *mpu, uint32_t pedal_buf[4])
 	memcpy(pedal_buf, mpu->pedal_dma_buf, sizeof(mpu->pedal_dma_buf));
 }
 
-int8_t read_temp_sensor(mpu_t *mpu, uint16_t *temp, uint16_t *humidity)
-{
-	if (!mpu)
-		return -1;
+// int8_t read_temp_sensor(mpu_t *mpu, uint16_t *temp, uint16_t *humidity)
+// {
+// 	if (!mpu)
+// 		return -1;
 
-	osStatus_t mut_stat = osMutexAcquire(mpu->i2c_mutex, osWaitForever);
-	if (mut_stat)
-		return mut_stat;
+// 	osStatus_t mut_stat = osMutexAcquire(mpu->i2c_mutex, osWaitForever);
+// 	if (mut_stat)
+// 		return mut_stat;
 
-	HAL_StatusTypeDef hal_stat = sht30_get_temp_humid(mpu->temp_sensor);
-	if (hal_stat)
-		return hal_stat;
+// 	HAL_StatusTypeDef hal_stat = sht30_get_temp_humid(mpu->temp_sensor);
+// 	if (hal_stat)
+// 		return hal_stat;
 
-	*temp = mpu->temp_sensor->temp;
-	*humidity = mpu->temp_sensor->humidity;
+// 	*temp = mpu->temp_sensor->temp;
+// 	*humidity = mpu->temp_sensor->humidity;
 
-	osMutexRelease(mpu->i2c_mutex);
-	return 0;
-}
+// 	osMutexRelease(mpu->i2c_mutex);
+// 	return 0;
+// }
 
-int8_t read_accel(mpu_t *mpu)
-{
-	if (!mpu)
-		return -1;
+// int8_t read_accel(mpu_t *mpu)
+// {
+// 	if (!mpu)
+// 		return -1;
 
-	osStatus_t mut_stat = osMutexAcquire(mpu->i2c_mutex, osWaitForever);
-	if (mut_stat)
-		return mut_stat;
+// 	osStatus_t mut_stat = osMutexAcquire(mpu->i2c_mutex, osWaitForever);
+// 	if (mut_stat)
+// 		return mut_stat;
 
-	HAL_StatusTypeDef hal_stat = lsm6dso_read_accel(mpu->imu);
-	if (hal_stat)
-		return hal_stat;
+// 	HAL_StatusTypeDef hal_stat = lsm6dso_read_accel(mpu->imu);
+// 	if (hal_stat)
+// 		return hal_stat;
 
-	osMutexRelease(mpu->i2c_mutex);
-	return 0;
-}
+// 	osMutexRelease(mpu->i2c_mutex);
+// 	return 0;
+// }
 
-int8_t read_gyro(mpu_t *mpu)
-{
-	if (!mpu)
-		return -1;
+// int8_t read_gyro(mpu_t *mpu)
+// {
+// 	if (!mpu)
+// 		return -1;
 
-	osStatus_t mut_stat = osMutexAcquire(mpu->i2c_mutex, osWaitForever);
-	if (mut_stat)
-		return mut_stat;
+// 	osStatus_t mut_stat = osMutexAcquire(mpu->i2c_mutex, osWaitForever);
+// 	if (mut_stat)
+// 		return mut_stat;
 
-	HAL_StatusTypeDef hal_stat = lsm6dso_read_gyro(mpu->imu);
-	if (hal_stat)
-		return hal_stat;
+// 	HAL_StatusTypeDef hal_stat = lsm6dso_read_gyro(mpu->imu);
+// 	if (hal_stat)
+// 		return hal_stat;
 
-	osMutexRelease(mpu->i2c_mutex);
-	return 0;
-}
+// 	osMutexRelease(mpu->i2c_mutex);
+// 	return 0;
+// }

--- a/Core/Src/mpu.c
+++ b/Core/Src/mpu.c
@@ -185,11 +185,9 @@ void read_pedals(mpu_t *mpu, uint32_t pedal_buf[4])
 // 	if (hal_stat)
 // 		return hal_stat;
 
-
 // 	osMutexRelease(mpu->i2c_mutex);
 // 	return 0;
 // }
-	
 
 int8_t write_fault(mpu_t *mpu, bool status)
 {

--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,6 @@ Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_tim.c \
 Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_tim_ex.c \
 Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_i2c.c \
 Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_i2c_ex.c \
-Drivers/Embedded-Base/general/src/lsm6dso.c \
-Drivers/Embedded-Base/general/src/sht30.c \
 Drivers/Embedded-Base/general/src/max7314.c \
 Drivers/Embedded-Base/platforms/stm32f405/src/can.c \
 Drivers/Embedded-Base/general/src/pi4ioe.c \


### PR DESCRIPTION
Removes lsm6dso and sht30 via ugly comment out.

Rationale:
The drivers are undergoing breaking changes tested in MSB-FW, so rather than untestedly fix cerb, lets comment them out.  Then #172 will become the PR which reintroduces them and takes inspo from MSB-FW for doing them cleanly.