### PR TITLE
Add TSMS override

### DIFF
--- a/Core/Src/nero.c
+++ b/Core/Src/nero.c
@@ -1,17 +1,17 @@
 #include "nero.h"
-#include "stdint.h"
-#include "stdbool.h"
-#include "can_handler.h"
-#include "state_machine.h"
-#include "queues.h"
 #include "c_utils.h"
-#include "stdio.h"
+#include "can_handler.h"
 #include "cerberus_conf.h"
 #include "monitor.h"
 #include "pedals.h"
+#include "queues.h"
+#include "state_machine.h"
+#include "stdbool.h"
+#include "stdint.h"
+#include "stdio.h"
 #include "string.h"
 
-//#define TORQUE_DEBUG
+// #define TORQUE_DEBUG
 
 static int8_t mph = 0;
 
@@ -25,7 +25,8 @@ void send_nero_msg()
 		uint8_t torque_lim_percentage;
 	} nero_data;
 
-	/* Since the screen on NERO relies on the NERO index, and reverse and pit have the same index, reverse gets a special index */
+	/* Since the screen on NERO relies on the NERO index, and reverse and pit have the same index,
+	 * reverse gets a special index */
 	if (get_func_state() == REVERSE) {
 		nero_data.nero_index = 255;
 	} else {
@@ -33,21 +34,20 @@ void send_nero_msg()
 	}
 
 	nero_data.home_mode = (uint8_t)get_nero_state().home_mode;
-	nero_data.mph = mph;
-	nero_data.tsms = (uint8_t)get_tsms();
+	nero_data.mph		= mph;
+	nero_data.tsms		= (uint8_t)get_tsms();
 	/* Percentage from 0 - 1, multiplied by 100 */
-	nero_data.torque_lim_percentage =
-		(uint8_t)(get_torque_limit_percentage() * 100);
+	nero_data.torque_lim_percentage = (uint8_t)(get_torque_limit_percentage() * 100);
 
 	can_msg_t msg = { .id = 0x501, .len = sizeof(nero_data) };
 
 	memcpy(&msg.data, &nero_data, sizeof(nero_data));
 
-	#ifdef TORQUE_DEBUG
-		nero_data.tsms = 1;
-		nero_data.nero_index = 1; /* Used for selecting drive mode */
-		dti_set_current(0);		
-	#endif
+#ifdef TORQUE_DEBUG
+	nero_data.tsms		 = 1;
+	nero_data.nero_index = 1; /* Used for selecting drive mode */
+	dti_set_current(0);
+#endif
 
 	/* Send CAN message */
 	queue_can_msg(msg);

--- a/Core/Src/nero.c
+++ b/Core/Src/nero.c
@@ -11,6 +11,8 @@
 #include "pedals.h"
 #include "string.h"
 
+//#define TORQUE_DEBUG
+
 static int8_t mph = 0;
 
 void send_nero_msg()
@@ -40,6 +42,12 @@ void send_nero_msg()
 	can_msg_t msg = { .id = 0x501, .len = sizeof(nero_data) };
 
 	memcpy(&msg.data, &nero_data, sizeof(nero_data));
+
+	#ifdef TORQUE_DEBUG
+		nero_data.tsms = 1;
+		nero_data.nero_index = 1; /* Used for selecting drive mode */
+		dti_set_current(0);		
+	#endif
 
 	/* Send CAN message */
 	queue_can_msg(msg);

--- a/Core/Src/nero.c
+++ b/Core/Src/nero.c
@@ -34,20 +34,21 @@ void send_nero_msg()
 	}
 
 	nero_data.home_mode = (uint8_t)get_nero_state().home_mode;
-	nero_data.mph		= mph;
-	nero_data.tsms		= (uint8_t)get_tsms();
+	nero_data.mph = mph;
+	nero_data.tsms = (uint8_t)get_tsms();
 	/* Percentage from 0 - 1, multiplied by 100 */
-	nero_data.torque_lim_percentage = (uint8_t)(get_torque_limit_percentage() * 100);
+	nero_data.torque_lim_percentage =
+		(uint8_t)(get_torque_limit_percentage() * 100);
+
+#ifdef TORQUE_DEBUG
+	nero_data.tsms = 1;
+	nero_data.nero_index = 1; /* Used for selecting drive mode */
+	dti_set_current(0);
+#endif
 
 	can_msg_t msg = { .id = 0x501, .len = sizeof(nero_data) };
 
 	memcpy(&msg.data, &nero_data, sizeof(nero_data));
-
-#ifdef TORQUE_DEBUG
-	nero_data.tsms		 = 1;
-	nero_data.nero_index = 1; /* Used for selecting drive mode */
-	dti_set_current(0);
-#endif
 
 	/* Send CAN message */
 	queue_can_msg(msg);


### PR DESCRIPTION
## Changes

Add a #ifdef which disables all of the above features to allow a user to debug the AC current output to the motor. This would be disabled by default and any usage of it should be conserved and clearly marked. Additionally, allow for overriding the current drive state.

## Checklist

- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Assign the PR to yourself
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket

Closes #246
