### PR TITLE
Tsms override

### DIFF
--- a/Core/Src/dti.c
+++ b/Core/Src/dti.c
@@ -100,7 +100,6 @@ void dti_set_current(int16_t current)
 
 #ifdef TSMS_OVERRIDE
 	dti_set_drive_enable(false);
-	printf("%d/n", current);
 #else
 	dti_set_drive_enable(true);
 #endif

--- a/Core/Src/dti.c
+++ b/Core/Src/dti.c
@@ -97,7 +97,14 @@ void dti_set_regen(uint16_t current_target)
 void dti_set_current(int16_t current)
 {
 	can_msg_t msg = { .id = 0x036, .len = 2, .data = { 0 } };
+
+#ifdef TSMS_OVERRIDE
+	dti_set_drive_enable(false);
+	printf("%d/n", current);
+#else
 	dti_set_drive_enable(true);
+#endif
+
 	/* Send CAN message in big endian format */
 
 	//endian_swap(&current, sizeof(current));

--- a/Core/Src/nero.c
+++ b/Core/Src/nero.c
@@ -1,17 +1,17 @@
 #include "nero.h"
-#include "stdint.h"
-#include "stdbool.h"
-#include "can_handler.h"
-#include "state_machine.h"
-#include "queues.h"
 #include "c_utils.h"
-#include "stdio.h"
+#include "can_handler.h"
 #include "cerberus_conf.h"
 #include "monitor.h"
 #include "pedals.h"
+#include "queues.h"
+#include "state_machine.h"
+#include "stdbool.h"
+#include "stdint.h"
+#include "stdio.h"
 #include "string.h"
 
-//#define TORQUE_DEBUG
+// #define TORQUE_DEBUG
 
 static int8_t mph = 0;
 
@@ -25,7 +25,8 @@ void send_nero_msg()
 		uint8_t torque_lim_percentage;
 	} nero_data;
 
-	/* Since the screen on NERO relies on the NERO index, and reverse and pit have the same index, reverse gets a special index */
+	/* Since the screen on NERO relies on the NERO index, and reverse and pit have the same index,
+	 * reverse gets a special index */
 	if (get_func_state() == REVERSE) {
 		nero_data.nero_index = 255;
 	} else {
@@ -33,21 +34,20 @@ void send_nero_msg()
 	}
 
 	nero_data.home_mode = (uint8_t)get_nero_state().home_mode;
-	nero_data.mph = mph;
-	nero_data.tsms = (uint8_t)get_tsms();
+	nero_data.mph		= mph;
+	nero_data.tsms		= (uint8_t)get_tsms();
 	/* Percentage from 0 - 1, multiplied by 100 */
-	nero_data.torque_lim_percentage =
-		(uint8_t)(get_torque_limit_percentage() * 100);
+	nero_data.torque_lim_percentage = (uint8_t)(get_torque_limit_percentage() * 100);
 
 	can_msg_t msg = { .id = 0x501, .len = sizeof(nero_data) };
 
 	memcpy(&msg.data, &nero_data, sizeof(nero_data));
 
-	#ifdef TORQUE_DEBUG
-		nero_data.tsms = 1;
-		nero_data.nero_index = 1; /* Used for selecting drive mode */
-		dti_set_current(0);		
-	#endif
+#ifdef TORQUE_DEBUG
+	nero_data.tsms		 = 1;
+	nero_data.nero_index = 1; /* Used for selecting drive mode */
+	dti_set_current(0);
+#endif
 
 	/* Send CAN message */
 	queue_can_msg(msg);

--- a/Core/Src/nero.c
+++ b/Core/Src/nero.c
@@ -40,12 +40,6 @@ void send_nero_msg()
 	nero_data.torque_lim_percentage =
 		(uint8_t)(get_torque_limit_percentage() * 100);
 
-#ifdef TORQUE_DEBUG
-	nero_data.tsms = 1;
-	nero_data.nero_index = 1; /* Used for selecting drive mode */
-	dti_set_current(0);
-#endif
-
 	can_msg_t msg = { .id = 0x501, .len = sizeof(nero_data) };
 
 	memcpy(&msg.data, &nero_data, sizeof(nero_data));

--- a/Core/Src/nero.c
+++ b/Core/Src/nero.c
@@ -11,6 +11,8 @@
 #include "pedals.h"
 #include "string.h"
 
+//#define TORQUE_DEBUG
+
 static int8_t mph = 0;
 
 void send_nero_msg()
@@ -40,6 +42,12 @@ void send_nero_msg()
 	can_msg_t msg = { .id = 0x501, .len = sizeof(nero_data) };
 
 	memcpy(&msg.data, &nero_data, sizeof(nero_data));
+
+	#ifdef TORQUE_DEBUG
+		nero_data.tsms = 1;
+		nero_data.nero_index = 1; /* Used for selecting drive mode */
+		dti_set_current(0);		
+	#endif
 
 	/* Send CAN message */
 	queue_can_msg(msg);

--- a/Core/Src/nero.c
+++ b/Core/Src/nero.c
@@ -34,20 +34,21 @@ void send_nero_msg()
 	}
 
 	nero_data.home_mode = (uint8_t)get_nero_state().home_mode;
-	nero_data.mph		= mph;
-	nero_data.tsms		= (uint8_t)get_tsms();
+	nero_data.mph = mph;
+	nero_data.tsms = (uint8_t)get_tsms();
 	/* Percentage from 0 - 1, multiplied by 100 */
-	nero_data.torque_lim_percentage = (uint8_t)(get_torque_limit_percentage() * 100);
+	nero_data.torque_lim_percentage =
+		(uint8_t)(get_torque_limit_percentage() * 100);
+
+#ifdef TORQUE_DEBUG
+	nero_data.tsms = 1;
+	nero_data.nero_index = 1; /* Used for selecting drive mode */
+	dti_set_current(0);
+#endif
 
 	can_msg_t msg = { .id = 0x501, .len = sizeof(nero_data) };
 
 	memcpy(&msg.data, &nero_data, sizeof(nero_data));
-
-#ifdef TORQUE_DEBUG
-	nero_data.tsms		 = 1;
-	nero_data.nero_index = 1; /* Used for selecting drive mode */
-	dti_set_current(0);
-#endif
 
 	/* Send CAN message */
 	queue_can_msg(msg);

--- a/Core/Src/state_machine.c
+++ b/Core/Src/state_machine.c
@@ -78,9 +78,15 @@ static int transition_functional_state(func_state_t new_state, pdu_t *pdu,
 			if (dti_get_mph(mc) > 1)
 				return 2;
 			/* Only turn on motor if brakes engaged and tsms is on */
+#ifdef TSMS_OVERRIDE
+			if (!get_brake_state()) {
+				return 3;
+			}
+#else
 			if (!get_brake_state() || !get_tsms()) {
 				return 3;
 			}
+#endif
 			osThreadFlagsSet(rtds_thread, SOUND_RTDS_FLAG);
 		}
 
@@ -110,11 +116,9 @@ static int transition_functional_state(func_state_t new_state, pdu_t *pdu,
 		// Do Nothing
 		break;
 	}
-#ifdef TSMS_OVERRIDE
-	cerberus_state.functional = READY;
-#else
+
 	cerberus_state.functional = new_state;
-#endif
+
 	return 0;
 }
 

--- a/Core/Src/state_machine.c
+++ b/Core/Src/state_machine.c
@@ -110,8 +110,11 @@ static int transition_functional_state(func_state_t new_state, pdu_t *pdu,
 		// Do Nothing
 		break;
 	}
-
+#ifdef TSMS_OVERRIDE
+	cerberus_state.functional = READY;
+#else
 	cerberus_state.functional = new_state;
+#endif
 	return 0;
 }
 

--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ LDFLAGS = $(MCU) -specs=nano.specs -T$(LDSCRIPT) $(LIBDIR) $(LIBS) -Wl,-Map=$(BU
 all: $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET).bin
 
 # motor Test
-CFLAGS += -DTSMS_OVERRIDE
+#CFLAGS += -DTSMS_OVERRIDE
 
 #######################################
 # build the application

--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,8 @@ LDFLAGS = $(MCU) -specs=nano.specs -T$(LDSCRIPT) $(LIBDIR) $(LIBS) -Wl,-Map=$(BU
 # default action: build all
 all: $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET).bin
 
+# motor Test
+CFLAGS += -DTSMS_OVERRIDE
 
 #######################################
 # build the application


### PR DESCRIPTION
## Changes

Add a #ifdef which disables all of the above features to allow a user to debug the AC current output to the motor. This would be disabled by default and any usage of it should be conserved and clearly marked. Additionally, allow for overriding the current drive state.

## Checklist

- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Assign the PR to yourself
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket

Closes #246
