### PR TITLE
Switch fuse and shutdown to bitfields

### DIFF
--- a/Core/Inc/pdu.h
+++ b/Core/Inc/pdu.h
@@ -36,17 +36,17 @@ int8_t write_fan_battbox(pdu_t *pdu, bool state);
 int8_t write_rtds(pdu_t *pdu, bool state);
 
 typedef struct {
-	char BATTBOX_FUSE_STAT : 1;
-	char LV_BOARDS_FUSE_STAT : 1;
-	char RADFAN_FUSE_STAT : 1;
-	char BUCK_FUSE_STAT : 1;
-	char FANBATTBOX_FUSE_STAT : 1;
-	char PUMP_FUSE_STAT0 : 1;
-	char DASHBOARD_FUSE_STAT : 1;
-	char BRKLIGHT_FUSE_STAT : 1;
-	char SD_TO_BRB_FUSE_STAT : 1;
-	char PUMP_FUSE_STAT1 : 1;
-	char MAX_FUSES : 1;
+	uint8_t BATTBOX_FUSE_STAT : 1;
+	uint8_t LV_BOARDS_FUSE_STAT : 1;
+	uint8_t RADFAN_FUSE_STAT : 1;
+	uint8_t BUCK_FUSE_STAT : 1;
+	uint8_t FANBATTBOX_FUSE_STAT : 1;
+	uint8_t PUMP_FUSE_STAT0 : 1;
+	uint8_t DASHBOARD_FUSE_STAT : 1;
+	uint8_t BRKLIGHT_FUSE_STAT : 1;
+	uint8_t SD_TO_BRB_FUSE_STAT : 1;
+	uint8_t PUMP_FUSE_STAT1 : 1;
+	uint8_t MAX_FUSES : 1;
 } fuse_bitfield;
 
 /**
@@ -68,18 +68,18 @@ int8_t read_fuses(pdu_t *pdu, fuse_bitfield *status);
 int8_t read_tsms_sense(pdu_t *pdu, bool *status);
 
 typedef struct {
-	char CKPT_BRB_CLR : 1; /* Cockpit BRB */
-	char BMS_GOOD : 1; /* Battery Management System (Shepherd) */
-	char INERTIA_SW_GOOD : 1; /* Inertia Switch */
-	char SPARE_GPIO1;
-	char IMD_GOOD : 1; /* Insulation Monitoring Device */
-	char BSPD_GOOD : 1; /* Brake System Plausbility Device */
-	char BOTS_GOOD : 1; /* Brake Over Travel Switch */
-	char HVD_INTLK_GOOD : 1; /* HVD Interlock */
-	char HVC_INTLK_GOOD : 1; /* HV C Interlock*/
-	//char SIDE_BRB_CLR : 1;	/* Side BRB */
-	//char TSMS : 1;			/* Tractive System Main Switch */
-	char MAX_SHUTDOWN_STAGES : 1;
+	uint8_t CKPT_BRB_CLR : 1; /* Cockpit BRB */
+	uint8_t BMS_GOOD : 1; /* Battery Management System (Shepherd) */
+	uint8_t INERTIA_SW_GOOD : 1; /* Inertia Switch */
+	uint8_t SPARE_GPIO1;
+	uint8_t IMD_GOOD : 1; /* Insulation Monitoring Device */
+	uint8_t BSPD_GOOD : 1; /* Brake System Plausbility Device */
+	uint8_t BOTS_GOOD : 1; /* Brake Over Travel Switch */
+	uint8_t HVD_INTLK_GOOD : 1; /* HVD Interlock */
+	uint8_t HVC_INTLK_GOOD : 1; /* HV C Interlock*/
+	//uint8_t SIDE_BRB_CLR : 1;	/* Side BRB */
+	//uint8_t TSMS : 1;			/* Tractive System Main Switch */
+	uint8_t MAX_SHUTDOWN_STAGES : 1;
 } shutdown_bitfield;
 
 /**

--- a/Core/Inc/pdu.h
+++ b/Core/Inc/pdu.h
@@ -35,23 +35,18 @@ int8_t write_brakelight(pdu_t *pdu, bool state);
 int8_t write_fan_battbox(pdu_t *pdu, bool state);
 int8_t write_rtds(pdu_t *pdu, bool state);
 
-/* Function to Read the Status of Fuses from PDU */
-typedef enum {
-	BATTBOX_FUSE_STAT = 0,
-	LV_BOARDS_FUSE_STAT,
-	RADFAN_FUSE_STAT,
-	BUCK_FUSE_STAT,
-	FANBATTBOX_FUSE_STAT,
-	PUMP_FUSE_STAT0,
-	DASHBOARD_FUSE_STAT,
-	BRKLIGHT_FUSE_STAT,
-	SD_TO_BRB_FUSE_STAT,
-	PUMP_FUSE_STAT1,
-	MAX_FUSES
-} fuse_t;
-
 typedef struct {
-	uint16_t f : 10; // 10 = fuse_t.values().length()
+	char BATTBOX_FUSE_STAT : 1;
+	char LV_BOARDS_FUSE_STAT : 1;
+	char RADFAN_FUSE_STAT : 1;
+	char BUCK_FUSE_STAT : 1;
+	char FANBATTBOX_FUSE_STAT : 1;
+	char PUMP_FUSE_STAT0 : 1;
+	char DASHBOARD_FUSE_STAT : 1;
+	char BRKLIGHT_FUSE_STAT : 1;
+	char SD_TO_BRB_FUSE_STAT : 1;
+	char PUMP_FUSE_STAT1 : 1;
+	char MAX_FUSES : 1;
 } fuse_bitfield;
 
 /**
@@ -72,24 +67,19 @@ int8_t read_fuses(pdu_t *pdu, fuse_bitfield *status);
  */
 int8_t read_tsms_sense(pdu_t *pdu, bool *status);
 
-/* Functions to Read Status of Various Stages of Shutdown Loop */
-typedef enum {
-	CKPT_BRB_CLR = 0, /* Cockpit BRB */
-	BMS_GOOD, /* Battery Management System (Shepherd) */
-	INERTIA_SW_GOOD, /* Inertia Switch */
-	SPARE_GPIO1,
-	IMD_GOOD, /* Insulation Monitoring Device */
-	BSPD_GOOD, /* Brake System Plausbility Device */
-	BOTS_GOOD, /* Brake Over Travel Switch */
-	HVD_INTLK_GOOD, /* HVD Interlock */
-	HVC_INTLK_GOOD, /* HV C Interlock*/
-	//SIDE_BRB_CLR,	/* Side BRB */
-	//TSMS,			/* Tractive System Main Switch */
-	MAX_SHUTDOWN_STAGES
-} shutdown_stage_t;
-
 typedef struct {
-	uint16_t s : 9; // 9 = shutdown_stage_t.values().length()
+	char CKPT_BRB_CLR : 1; /* Cockpit BRB */
+	char BMS_GOOD : 1; /* Battery Management System (Shepherd) */
+	char INERTIA_SW_GOOD : 1; /* Inertia Switch */
+	char SPARE_GPIO1;
+	char IMD_GOOD : 1; /* Insulation Monitoring Device */
+	char BSPD_GOOD : 1; /* Brake System Plausbility Device */
+	char BOTS_GOOD : 1; /* Brake Over Travel Switch */
+	char HVD_INTLK_GOOD : 1; /* HVD Interlock */
+	char HVC_INTLK_GOOD : 1; /* HV C Interlock*/
+	//char SIDE_BRB_CLR : 1;	/* Side BRB */
+	//char TSMS : 1;			/* Tractive System Main Switch */
+	char MAX_SHUTDOWN_STAGES : 1;
 } shutdown_bitfield;
 
 /**

--- a/Core/Inc/pdu.h
+++ b/Core/Inc/pdu.h
@@ -37,7 +37,7 @@ int8_t write_rtds(pdu_t *pdu, bool state);
 
 /* Function to Read the Status of Fuses from PDU */
 typedef enum {
-	BATTBOX_FUSE_STAT,
+	BATTBOX_FUSE_STAT = 0,
 	LV_BOARDS_FUSE_STAT,
 	RADFAN_FUSE_STAT,
 	BUCK_FUSE_STAT,
@@ -50,6 +50,10 @@ typedef enum {
 	MAX_FUSES
 } fuse_t;
 
+typedef struct {
+	uint16_t f : 10; // 10 = fuse_t.values().length()
+} fuse_bitfield;
+
 /**
  * @brief Read the status of the PDU fuses.
  * 
@@ -57,7 +61,7 @@ typedef enum {
  * @param status Buffer that fuse data will be written to
  * @return int8_t Error code resulting from reading GPIO expander pins over I2C or mutex acquisition
  */
-int8_t read_fuses(pdu_t *pdu, bool status[MAX_FUSES]);
+int8_t read_fuses(pdu_t *pdu, fuse_bitfield *status);
 
 /**
  * @brief Read the state of the TSMS signal.
@@ -70,7 +74,7 @@ int8_t read_tsms_sense(pdu_t *pdu, bool *status);
 
 /* Functions to Read Status of Various Stages of Shutdown Loop */
 typedef enum {
-	CKPT_BRB_CLR, /* Cockpit BRB */
+	CKPT_BRB_CLR = 0, /* Cockpit BRB */
 	BMS_GOOD, /* Battery Management System (Shepherd) */
 	INERTIA_SW_GOOD, /* Inertia Switch */
 	SPARE_GPIO1,
@@ -84,6 +88,10 @@ typedef enum {
 	MAX_SHUTDOWN_STAGES
 } shutdown_stage_t;
 
+typedef struct {
+	uint16_t s : 9; // 9 = shutdown_stage_t.values().length()
+} shutdown_bitfield;
+
 /**
  * @brief Read the status of the shutdown loop.
  * 
@@ -91,7 +99,7 @@ typedef enum {
  * @param status Buffer that fuse data will be written to
  * @return int8_t Result of reading pins on the shutdown monitor GPIO expander of the PDU or result of mutex acquisition
  */
-int8_t read_shutdown(pdu_t *pdu, bool status[MAX_SHUTDOWN_STAGES]);
+int8_t read_shutdown(pdu_t *pdu, shutdown_bitfield *status);
 
 /**
  * @brief Read the status of the shutdown loop.

--- a/Core/Src/monitor.c
+++ b/Core/Src/monitor.c
@@ -159,22 +159,25 @@ void read_fuse_data(void *arg)
 	fault_data_t fault_data = { .id = FUSE_MONITOR_FAULT,
 				    .severity = DEFCON5 };
 	can_msg_t fuse_msg = { .id = CANID_FUSE, .len = 2, .data = { 0 } };
-
+	uint16_t fuse_buf;
 	fuse_bitfield fuses;
-	fuses.f = 0;
 
 	struct __attribute__((__packed__)) {
 		uint8_t fuse_1;
 		uint8_t fuse_2;
 	} fuse_data;
 
+	fuse_buf = 0;
+
 	if (read_fuses(pdu, &fuses)) {
 		fault_data.diag = "Failed to read fuses";
 		queue_fault(&fault_data);
 	}
 
-	fuse_data.fuse_1 = fuses.f & 0xFF;
-	fuse_data.fuse_2 = (fuses.f >> 8) & 0xFF;
+	memcpy(&fuse_buf, &fuses, 2);
+
+	fuse_data.fuse_1 = fuse_buf & 0xFF;
+	fuse_data.fuse_2 = (fuse_buf >> 8) & 0xFF;
 
 	// reverse the bit order
 	fuse_data.fuse_1 = reverse_bits(fuse_data.fuse_1);
@@ -348,8 +351,8 @@ void vShutdownMonitor(void *pv_params)
 				   .len = 2,
 				   .data = { 0 } };
 	pdu_t *pdu = (pdu_t *)pv_params;
+	uint16_t shutdown_buf;
 	shutdown_bitfield shutdowns;
-	shutdowns.s = 0;
 
 	struct __attribute__((__packed__)) {
 		uint8_t shut_1;
@@ -357,14 +360,18 @@ void vShutdownMonitor(void *pv_params)
 	} shutdown_data;
 
 	for (;;) {
+		shutdown_buf = 0;
+
 		if (read_shutdown(pdu, &shutdowns)) {
 			fault_data.diag = "Failed to read shutdown buffer";
 			queue_fault(&fault_data);
 		}
 
+		memcpy(&shutdown_buf, &shutdowns, 2);
+
 		/* seperate each byte */
-		shutdown_data.shut_1 = shutdowns.s & 0xFF;
-		shutdown_data.shut_2 = (shutdowns.s >> 8) & 0xFF;
+		shutdown_data.shut_1 = shutdown_buf & 0xFF;
+		shutdown_data.shut_2 = (shutdown_buf >> 8) & 0xFF;
 
 		// reverse the bit order
 		shutdown_data.shut_1 = reverse_bits(shutdown_data.shut_1);

--- a/Core/Src/monitor.c
+++ b/Core/Src/monitor.c
@@ -351,7 +351,7 @@ void vShutdownMonitor(void *pv_params)
 				   .len = 2,
 				   .data = { 0 } };
 	pdu_t *pdu = (pdu_t *)pv_params;
-	uint16_t shutdown_buf;
+	uint32_t shutdown_buf;
 	shutdown_bitfield shutdowns;
 
 	struct __attribute__((__packed__)) {

--- a/Core/Src/monitor.c
+++ b/Core/Src/monitor.c
@@ -174,7 +174,7 @@ void read_fuse_data(void *arg)
 		queue_fault(&fault_data);
 	}
 
-	memcpy(&fuse_buf, &fuses, 2);
+	memcpy(&fuse_buf, &fuses, sizeof(fuses));
 
 	fuse_data.fuse_1 = fuse_buf & 0xFF;
 	fuse_data.fuse_2 = (fuse_buf >> 8) & 0xFF;
@@ -367,7 +367,7 @@ void vShutdownMonitor(void *pv_params)
 			queue_fault(&fault_data);
 		}
 
-		memcpy(&shutdown_buf, &shutdowns, 2);
+		memcpy(&shutdown_buf, &shutdowns, sizeof(shutdowns));
 
 		/* seperate each byte */
 		shutdown_data.shut_1 = shutdown_buf & 0xFF;

--- a/Core/Src/monitor.c
+++ b/Core/Src/monitor.c
@@ -159,29 +159,22 @@ void read_fuse_data(void *arg)
 	fault_data_t fault_data = { .id = FUSE_MONITOR_FAULT,
 				    .severity = DEFCON5 };
 	can_msg_t fuse_msg = { .id = CANID_FUSE, .len = 2, .data = { 0 } };
-	uint16_t fuse_buf;
-	bool fuses[MAX_FUSES] = { 0 };
+
+	fuse_bitfield fuses;
+	fuses.f = 0;
 
 	struct __attribute__((__packed__)) {
 		uint8_t fuse_1;
 		uint8_t fuse_2;
 	} fuse_data;
 
-	fuse_buf = 0;
-
-	if (read_fuses(pdu, fuses)) {
+	if (read_fuses(pdu, &fuses)) {
 		fault_data.diag = "Failed to read fuses";
 		queue_fault(&fault_data);
 	}
 
-	for (fuse_t fuse = 0; fuse < MAX_FUSES; fuse++) {
-		fuse_buf |=
-			fuses[fuse]
-			<< fuse; /* Sets the bit at position `fuse` to the state of the fuse */
-	}
-
-	fuse_data.fuse_1 = fuse_buf & 0xFF;
-	fuse_data.fuse_2 = (fuse_buf >> 8) & 0xFF;
+	fuse_data.fuse_1 = fuses.f & 0xFF;
+	fuse_data.fuse_2 = (fuses.f >> 8) & 0xFF;
 
 	// reverse the bit order
 	fuse_data.fuse_1 = reverse_bits(fuse_data.fuse_1);
@@ -355,8 +348,8 @@ void vShutdownMonitor(void *pv_params)
 				   .len = 2,
 				   .data = { 0 } };
 	pdu_t *pdu = (pdu_t *)pv_params;
-	bool shutdown_loop[MAX_SHUTDOWN_STAGES] = { 0 };
-	uint16_t shutdown_buf;
+	shutdown_bitfield shutdowns;
+	shutdowns.s = 0;
 
 	struct __attribute__((__packed__)) {
 		uint8_t shut_1;
@@ -364,23 +357,14 @@ void vShutdownMonitor(void *pv_params)
 	} shutdown_data;
 
 	for (;;) {
-		shutdown_buf = 0;
-
-		if (read_shutdown(pdu, shutdown_loop)) {
+		if (read_shutdown(pdu, &shutdowns)) {
 			fault_data.diag = "Failed to read shutdown buffer";
 			queue_fault(&fault_data);
 		}
 
-		for (shutdown_stage_t stage = 0; stage < MAX_SHUTDOWN_STAGES;
-		     stage++) {
-			shutdown_buf |=
-				shutdown_loop[stage]
-				<< stage; /* Sets the bit at position `stage` to the state of the stage */
-		}
-
 		/* seperate each byte */
-		shutdown_data.shut_1 = shutdown_buf & 0xFF;
-		shutdown_data.shut_2 = (shutdown_buf >> 8) & 0xFF;
+		shutdown_data.shut_1 = shutdowns.s & 0xFF;
+		shutdown_data.shut_2 = (shutdowns.s >> 8) & 0xFF;
 
 		// reverse the bit order
 		shutdown_data.shut_1 = reverse_bits(shutdown_data.shut_1);

--- a/Core/Src/pdu.c
+++ b/Core/Src/pdu.c
@@ -295,23 +295,17 @@ int8_t read_fuses(pdu_t *pdu, fuse_bitfield *status)
 		return error;
 	}
 
-	status->f |= ((bank0_d >> PIN_BATTBOX_FUSE_STAT) & 1)
-		     << BATTBOX_FUSE_STAT;
-	status->f |= ((bank0_d >> PIN_LV_BOARDS_FUSE_STAT) & 1)
-		     << LV_BOARDS_FUSE_STAT;
-	status->f |= ((bank0_d >> PIN_RADFAN_FUSE_STAT) & 1)
-		     << RADFAN_FUSE_STAT;
-	status->f |= ((bank1_d >> PIN_BUCK_FUSE_STAT) & 1) << BUCK_FUSE_STAT;
-	status->f |= ((bank1_d >> PIN_FANBATTBOX_FUSE_STAT) & 1)
-		     << FANBATTBOX_FUSE_STAT;
-	status->f |= ((bank1_d >> PIN_PUMP_FUSE_STAT0) & 1) << PUMP_FUSE_STAT0;
-	status->f |= ((bank1_d >> PIN_DASHBOARD_FUSE_STAT) & 1)
-		     << DASHBOARD_FUSE_STAT;
-	status->f |= ((bank1_d >> PIN_BRKLIGHT_FUSE_STAT) & 1)
-		     << BRKLIGHT_FUSE_STAT;
-	status->f |= ((bank1_d >> PIN_SD_TO_BRB_FUSE_STAT) & 1)
-		     << SD_TO_BRB_FUSE_STAT;
-	status->f |= ((bank1_d >> PIN_PUMP_FUSE_STAT1) & 1) << PUMP_FUSE_STAT1;
+	status->BATTBOX_FUSE_STAT = (bank0_d >> PIN_BATTBOX_FUSE_STAT) & 1;
+	status->LV_BOARDS_FUSE_STAT = (bank0_d >> PIN_LV_BOARDS_FUSE_STAT) & 1;
+	status->RADFAN_FUSE_STAT = (bank0_d >> PIN_RADFAN_FUSE_STAT) & 1;
+	status->BUCK_FUSE_STAT = (bank1_d >> PIN_BUCK_FUSE_STAT) & 1;
+	status->FANBATTBOX_FUSE_STAT = (bank1_d >> PIN_FANBATTBOX_FUSE_STAT) &
+				       1;
+	status->PUMP_FUSE_STAT0 = (bank1_d >> PIN_PUMP_FUSE_STAT0) & 1;
+	status->DASHBOARD_FUSE_STAT = (bank1_d >> PIN_DASHBOARD_FUSE_STAT) & 1;
+	status->BRKLIGHT_FUSE_STAT = (bank1_d >> PIN_BRKLIGHT_FUSE_STAT) & 1;
+	status->SD_TO_BRB_FUSE_STAT = (bank1_d >> PIN_SD_TO_BRB_FUSE_STAT) & 1;
+	status->PUMP_FUSE_STAT1 = (bank1_d >> PIN_PUMP_FUSE_STAT1) & 1;
 
 	osMutexRelease(pdu->mutex);
 	return 0;
@@ -365,15 +359,15 @@ int8_t read_shutdown(pdu_t *pdu, shutdown_bitfield *status)
 		return error;
 	}
 
-	status->s |= ((bank0_d >> PIN_CKPT_BRB_CLR) & 1) << CKPT_BRB_CLR;
-	status->s |= ((bank0_d >> PIN_BMS_GOOD) & 1) << BMS_GOOD;
-	status->s |= ((bank0_d >> PIN_INERTIA_SW_GOOD) & 1) << INERTIA_SW_GOOD;
-	status->s |= ((bank0_d >> PIN_SPARE_GPIO1) & 1) << SPARE_GPIO1;
-	status->s |= ((bank0_d >> PIN_IMD_GOOD) & 1) << IMD_GOOD;
-	status->s |= ((bank0_d >> PIN_BSPD_GOOD) & 1) << BSPD_GOOD;
-	status->s |= ((bank1_d >> PIN_BOTS_GOOD) & 1) << BOTS_GOOD;
-	status->s |= ((bank1_d >> PIN_HVD_INTLK_GOOD) & 1) << HVD_INTLK_GOOD;
-	status->s |= ((bank1_d >> PIN_HVC_INTLK_GOOD) & 1) << HVC_INTLK_GOOD;
+	status->CKPT_BRB_CLR = (bank0_d >> PIN_CKPT_BRB_CLR) & 1;
+	status->BMS_GOOD = (bank0_d >> PIN_BMS_GOOD) & 1;
+	status->INERTIA_SW_GOOD = (bank0_d >> PIN_INERTIA_SW_GOOD) & 1;
+	status->SPARE_GPIO1 = (bank0_d >> PIN_SPARE_GPIO1) & 1;
+	status->IMD_GOOD = (bank0_d >> PIN_IMD_GOOD) & 1;
+	status->BSPD_GOOD = (bank0_d >> PIN_BSPD_GOOD) & 1;
+	status->BOTS_GOOD = (bank1_d >> PIN_BOTS_GOOD) & 1;
+	status->HVD_INTLK_GOOD = (bank1_d >> PIN_HVD_INTLK_GOOD) & 1;
+	status->HVC_INTLK_GOOD = (bank1_d >> PIN_HVC_INTLK_GOOD) & 1;
 
 	osMutexRelease(pdu->mutex);
 	return 0;

--- a/Core/Src/pdu.c
+++ b/Core/Src/pdu.c
@@ -299,8 +299,7 @@ int8_t read_fuses(pdu_t *pdu, fuse_bitfield *status)
 	status->LV_BOARDS_FUSE_STAT = (bank0_d >> PIN_LV_BOARDS_FUSE_STAT) & 1;
 	status->RADFAN_FUSE_STAT = (bank0_d >> PIN_RADFAN_FUSE_STAT) & 1;
 	status->BUCK_FUSE_STAT = (bank1_d >> PIN_BUCK_FUSE_STAT) & 1;
-	status->FANBATTBOX_FUSE_STAT = (bank1_d >> PIN_FANBATTBOX_FUSE_STAT) &
-				       1;
+	status->FANBATTBOX_FUSE_STAT = (bank1_d >> PIN_BATTBOX_FUSE_STAT) & 1;
 	status->PUMP_FUSE_STAT0 = (bank1_d >> PIN_PUMP_FUSE_STAT0) & 1;
 	status->DASHBOARD_FUSE_STAT = (bank1_d >> PIN_DASHBOARD_FUSE_STAT) & 1;
 	status->BRKLIGHT_FUSE_STAT = (bank1_d >> PIN_BRKLIGHT_FUSE_STAT) & 1;
@@ -359,15 +358,15 @@ int8_t read_shutdown(pdu_t *pdu, shutdown_bitfield *status)
 		return error;
 	}
 
-	status->CKPT_BRB_CLR = (bank0_d >> PIN_CKPT_BRB_CLR) & 1;
+	status->CKPT_BRB_CLR = (bank0_d >> PIN_CKPT_BRB) & 1;
 	status->BMS_GOOD = (bank0_d >> PIN_BMS_GOOD) & 1;
 	status->INERTIA_SW_GOOD = (bank0_d >> PIN_INERTIA_SW_GOOD) & 1;
-	status->SPARE_GPIO1 = (bank0_d >> PIN_SPARE_GPIO1) & 1;
+	status->SPARE_GPIO1 = (bank0_d >> PIN_SPARE_GPIO0) & 1;
 	status->IMD_GOOD = (bank0_d >> PIN_IMD_GOOD) & 1;
 	status->BSPD_GOOD = (bank0_d >> PIN_BSPD_GOOD) & 1;
 	status->BOTS_GOOD = (bank1_d >> PIN_BOTS_GOOD) & 1;
-	status->HVD_INTLK_GOOD = (bank1_d >> PIN_HVD_INTLK_GOOD) & 1;
-	status->HVC_INTLK_GOOD = (bank1_d >> PIN_HVC_INTLK_GOOD) & 1;
+	status->HVD_INTLK_GOOD = (bank1_d >> PIN_HVD_GOOD) & 1;
+	status->HVC_INTLK_GOOD = (bank1_d >> PIN_HVC_GOOD) & 1;
 
 	osMutexRelease(pdu->mutex);
 	return 0;

--- a/Core/Src/pdu.c
+++ b/Core/Src/pdu.c
@@ -271,14 +271,7 @@ void read_pump_sensors(pdu_t *pdu, uint32_t pump_sensors_buf[2])
 	       sizeof(pdu->pump_sensors_dma_buf));
 }
 
-static void deconstruct_buf(uint8_t data, bool config[8])
-{
-	for (uint8_t i = 0; i < 8; i++) {
-		config[i] = (data >> i) & 1;
-	}
-}
-
-int8_t read_fuses(pdu_t *pdu, bool status[MAX_FUSES])
+int8_t read_fuses(pdu_t *pdu, fuse_bitfield *status)
 {
 	if (!pdu)
 		return -1;
@@ -302,22 +295,23 @@ int8_t read_fuses(pdu_t *pdu, bool status[MAX_FUSES])
 		return error;
 	}
 
-	bool bank0[8];
-	deconstruct_buf(bank0_d, bank0);
-
-	bool bank1[8];
-	deconstruct_buf(bank1_d, bank1);
-
-	status[BATTBOX_FUSE_STAT] = bank0[PIN_BATTBOX_FUSE_STAT];
-	status[LV_BOARDS_FUSE_STAT] = bank0[PIN_LV_BOARDS_FUSE_STAT];
-	status[RADFAN_FUSE_STAT] = bank0[PIN_RADFAN_FUSE_STAT];
-	status[BUCK_FUSE_STAT] = bank1[PIN_BUCK_FUSE_STAT];
-	status[FANBATTBOX_FUSE_STAT] = bank1[PIN_FANBATTBOX_FUSE_STAT];
-	status[PUMP_FUSE_STAT0] = bank1[PIN_PUMP_FUSE_STAT0];
-	status[DASHBOARD_FUSE_STAT] = bank1[PIN_DASHBOARD_FUSE_STAT];
-	status[BRKLIGHT_FUSE_STAT] = bank1[PIN_BRKLIGHT_FUSE_STAT];
-	status[SD_TO_BRB_FUSE_STAT] = bank1[PIN_SD_TO_BRB_FUSE_STAT];
-	status[PUMP_FUSE_STAT1] = bank1[PIN_PUMP_FUSE_STAT1];
+	status->f |= ((bank0_d >> PIN_BATTBOX_FUSE_STAT) & 1)
+		     << BATTBOX_FUSE_STAT;
+	status->f |= ((bank0_d >> PIN_LV_BOARDS_FUSE_STAT) & 1)
+		     << LV_BOARDS_FUSE_STAT;
+	status->f |= ((bank0_d >> PIN_RADFAN_FUSE_STAT) & 1)
+		     << RADFAN_FUSE_STAT;
+	status->f |= ((bank1_d >> PIN_BUCK_FUSE_STAT) & 1) << BUCK_FUSE_STAT;
+	status->f |= ((bank1_d >> PIN_FANBATTBOX_FUSE_STAT) & 1)
+		     << FANBATTBOX_FUSE_STAT;
+	status->f |= ((bank1_d >> PIN_PUMP_FUSE_STAT0) & 1) << PUMP_FUSE_STAT0;
+	status->f |= ((bank1_d >> PIN_DASHBOARD_FUSE_STAT) & 1)
+		     << DASHBOARD_FUSE_STAT;
+	status->f |= ((bank1_d >> PIN_BRKLIGHT_FUSE_STAT) & 1)
+		     << BRKLIGHT_FUSE_STAT;
+	status->f |= ((bank1_d >> PIN_SD_TO_BRB_FUSE_STAT) & 1)
+		     << SD_TO_BRB_FUSE_STAT;
+	status->f |= ((bank1_d >> PIN_PUMP_FUSE_STAT1) & 1) << PUMP_FUSE_STAT1;
 
 	osMutexRelease(pdu->mutex);
 	return 0;
@@ -347,7 +341,7 @@ int8_t read_tsms_sense(pdu_t *pdu, bool *status)
 	return 0;
 }
 
-int8_t read_shutdown(pdu_t *pdu, bool status[MAX_SHUTDOWN_STAGES])
+int8_t read_shutdown(pdu_t *pdu, shutdown_bitfield *status)
 {
 	if (!pdu)
 		return -1;
@@ -371,21 +365,15 @@ int8_t read_shutdown(pdu_t *pdu, bool status[MAX_SHUTDOWN_STAGES])
 		return error;
 	}
 
-	bool bank0[8];
-	deconstruct_buf(bank0_d, bank0);
-
-	bool bank1[8];
-	deconstruct_buf(bank1_d, bank1);
-
-	status[CKPT_BRB_CLR] = bank0[PIN_CKPT_BRB_CLR];
-	status[BMS_GOOD] = bank0[PIN_BMS_GOOD];
-	status[INERTIA_SW_GOOD] = bank0[PIN_INERTIA_SW_GOOD];
-	status[SPARE_GPIO1] = bank0[PIN_SPARE_GPIO1];
-	status[IMD_GOOD] = bank0[PIN_IMD_GOOD];
-	status[BSPD_GOOD] = bank0[PIN_BSPD_GOOD];
-	status[BOTS_GOOD] = bank1[PIN_BOTS_GOOD];
-	status[HVD_INTLK_GOOD] = bank1[PIN_HVD_INTLK_GOOD];
-	status[HVC_INTLK_GOOD] = bank1[PIN_HVC_INTLK_GOOD];
+	status->s |= ((bank0_d >> PIN_CKPT_BRB_CLR) & 1) << CKPT_BRB_CLR;
+	status->s |= ((bank0_d >> PIN_BMS_GOOD) & 1) << BMS_GOOD;
+	status->s |= ((bank0_d >> PIN_INERTIA_SW_GOOD) & 1) << INERTIA_SW_GOOD;
+	status->s |= ((bank0_d >> PIN_SPARE_GPIO1) & 1) << SPARE_GPIO1;
+	status->s |= ((bank0_d >> PIN_IMD_GOOD) & 1) << IMD_GOOD;
+	status->s |= ((bank0_d >> PIN_BSPD_GOOD) & 1) << BSPD_GOOD;
+	status->s |= ((bank1_d >> PIN_BOTS_GOOD) & 1) << BOTS_GOOD;
+	status->s |= ((bank1_d >> PIN_HVD_INTLK_GOOD) & 1) << HVD_INTLK_GOOD;
+	status->s |= ((bank1_d >> PIN_HVC_INTLK_GOOD) & 1) << HVC_INTLK_GOOD;
 
 	osMutexRelease(pdu->mutex);
 	return 0;


### PR DESCRIPTION
## Changes

Replaced the bool array with a bit field and removed the deconstruct buff and other buffers as they were now redundant.

## Test Cases

- built
- still need to test on test bench

Closes #266
