### PR TITLE
Feature/disable reverse

### DIFF
--- a/Core/Src/state_machine.c
+++ b/Core/Src/state_machine.c
@@ -13,7 +13,7 @@
 
 #define SEND_NERO_TIMEOUT 500 /*in millis*/
 
-#define DISABLE_REVERSE
+//#define DISABLE_REVERSE
 
 /* Internal State of Vehicle */
 static state_t cerberus_state;

--- a/Core/Src/state_machine.c
+++ b/Core/Src/state_machine.c
@@ -13,7 +13,7 @@
 
 #define SEND_NERO_TIMEOUT 500 /*in millis*/
 
-//#define DISABLE_REVERSE
+#define DISABLE_REVERSE
 
 /* Internal State of Vehicle */
 static state_t cerberus_state;

--- a/Core/Src/state_machine.c
+++ b/Core/Src/state_machine.c
@@ -13,6 +13,8 @@
 
 #define SEND_NERO_TIMEOUT 500 /*in millis*/
 
+//#define DISABLE_REVERSE
+
 /* Internal State of Vehicle */
 static state_t cerberus_state;
 
@@ -173,6 +175,7 @@ static int transition_nero_state(nero_state_t new_state, pdu_t *pdu, dti_t *mc,
 	if (new_state.nero_index >= MAX_NERO_STATES)
 		new_state.nero_index = MAX_NERO_STATES - 1;
 
+#ifndef DISABLE_REVERSE
 	// Wasn't in home mode and still are not in home mode (Infer a Select Request)
 	if (!current_nero_state.home_mode && !new_state.home_mode) {
 		// Only Check if we are in pit mode to toggle direction
@@ -188,6 +191,7 @@ static int transition_nero_state(nero_state_t new_state, pdu_t *pdu, dti_t *mc,
 			}
 		}
 	}
+#endif 
 
 	// Selecting a mode on NERO
 	if (current_nero_state.home_mode && !new_state.home_mode) {

--- a/Core/Src/state_machine.c
+++ b/Core/Src/state_machine.c
@@ -191,7 +191,7 @@ static int transition_nero_state(nero_state_t new_state, pdu_t *pdu, dti_t *mc,
 			}
 		}
 	}
-#endif 
+#endif
 
 	// Selecting a mode on NERO
 	if (current_nero_state.home_mode && !new_state.home_mode) {


### PR DESCRIPTION
## Changes

Made a global variable that defined whether reversing is disabled or not. Reverse messages do not send if REVERSE_DISABLED is defined.

## Notes

none

## Test Cases

Built when was defined and also when commented out.

## To Do

No fault torque stuff.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please reach out to your Project Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ *] No merge conflicts
- [* ] All checks passing
- [ *] Remove any non-applicable sections of this template
- [* ] Assign the PR to yourself
- [* ] Request reviewers & ping on Slack
- [ *] PR is linked to the ticket (fill in the closes line below)

Closes #245 
