### PR TITLE
Added Torque Dial Driver IO

### DIFF
--- a/Core/Inc/pedals.h
+++ b/Core/Inc/pedals.h
@@ -42,6 +42,15 @@ void increase_torque_limit();
 void decrease_torque_limit();
 
 /**
+ * @brief Sets the torque limit to a specific percentage
+ * 
+ * @param percentage Percentage of the torque limit. Acceptable values are between 0 and 1.
+ * 
+ * @return uint8_t Error code. 0 if successful, 1 if percentage is out of bounds.
+ */
+uint8_t set_torque_limit(float percentage);
+
+/**
  * @brief Get the current torque limit percentage
  * 
  * @return torque limit percentage

--- a/Core/Inc/pedals.h
+++ b/Core/Inc/pedals.h
@@ -44,11 +44,10 @@ void decrease_torque_limit();
 /**
  * @brief Sets the torque limit to a specific percentage
  * 
- * @param percentage Percentage of the torque limit. Acceptable values are between 0 and 1.
+ * @param percentage Percentage of the torque limit. Acceptable values are between 0.0 and 1.0.
  * 
- * @return uint8_t Error code. 0 if successful, 1 if percentage is out of bounds.
  */
-uint8_t set_torque_limit(float percentage);
+void set_torque_limit(float percentage);
 
 /**
  * @brief Get the current torque limit percentage

--- a/Core/Inc/steeringio.h
+++ b/Core/Inc/steeringio.h
@@ -3,7 +3,8 @@
 
 #include "can.h"
 
-#define STEERING_CANID_IO 0x680
+#define BUTTON_CANID_IO 0x680
+#define DIAL_CANID_IO	0x681
 
 typedef enum {
 	BUTTON_LEFT,
@@ -12,14 +13,31 @@ typedef enum {
 	BUTTON_UP,
 	BUTTON_DOWN,
 	BUTTON_ENTER,
+	BUTTON_SPARE,
 	MAX_STEERING_BUTTONS
 } steeringio_button_t;
+
+typedef enum {
+	DIAL_SWITCH_1,
+	DIAL_SWITCH_2,
+	DIAL_SWITCH_3,
+	DIAL_SWITCH_4,
+	DIAL_SWITCH_5,
+	MAX_DIAL_SIZE,
+} steeringio_dial_t;
 
 /**
  * @brief Update the status of the steering wheel buttons.
  *
  * @param can_msg can message containing data update
  */
-void steeringio_update(can_msg_t can_msg);
+void buttons_update(can_msg_t can_msg);
+
+/**
+ * @brief Update the status of the active steering wheel dial switch.
+ *
+ * @param can_msg can message containing data update
+ */
+void dial_update(can_msg_t can_msg);
 
 #endif /* STEERING_H */

--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -23,7 +23,7 @@ can_t *can1;
 
 /* Relevant Info for Initializing CAN 1 */
 static uint32_t id_list[] = { DTI_CANID_ERPM, DTI_CANID_CURRENTS, BMS_DCL_MSG,
-			      STEERING_CANID_IO };
+			      BUTTON_CANID_IO, DIAL_CANID_IO };
 
 void init_can1(CAN_HandleTypeDef *hcan)
 {

--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -150,8 +150,11 @@ void vCanReceive(void *pv_params)
 			case BMS_DCL_MSG:
 				handle_dcl_msg();
 				break;
-			case STEERING_CANID_IO:
-				steeringio_update(msg);
+			case BUTTON_CANID_IO:
+				buttons_update(msg);
+				break;
+			case DIAL_CANID_IO:
+				dial_update(msg);
 				break;
 			default:
 				break;

--- a/Core/Src/pedals.c
+++ b/Core/Src/pedals.c
@@ -57,14 +57,16 @@ void decrease_torque_limit()
 	}
 }
 
-uint8_t set_torque_limit(float percentage)
+void set_torque_limit(float percentage)
 {
-	// If the percentage is out of bounds, return an error.
-	if (percentage < 0 || percentage > 1) {
-		return 1;
-	}
 	torque_limit_percentage = percentage;
-	return 0;
+
+	// Make sure the percentage is within the valid range
+	if (torque_limit_percentage > 1.0) {
+		torque_limit_percentage = 1.0;
+	} else if (torque_limit_percentage < 0.0) {
+		torque_limit_percentage = 0.0;
+	}
 }
 
 float get_torque_limit_percentage()

--- a/Core/Src/pedals.c
+++ b/Core/Src/pedals.c
@@ -57,6 +57,16 @@ void decrease_torque_limit()
 	}
 }
 
+uint8_t set_torque_limit(float percentage)
+{
+	// If the percentage is out of bounds, return an error.
+	if (percentage < 0 || percentage > 1) {
+		return 1;
+	}
+	torque_limit_percentage = percentage;
+	return 0;
+}
+
 float get_torque_limit_percentage()
 {
 	return torque_limit_percentage;

--- a/Core/Src/steeringio.c
+++ b/Core/Src/steeringio.c
@@ -21,7 +21,7 @@ static void right_button_cb()
 	}
 }
 
-void steeringio_update(can_msg_t msg)
+void buttons_update(can_msg_t msg)
 {
 	uint8_t button_id = msg.data[0];
 
@@ -51,6 +51,29 @@ void steeringio_update(can_msg_t msg)
 		select_nero_index();
 		break;
 	default:
+		break;
+	}
+}
+
+void dial_update(can_msg_t msg)
+{
+	uint8_t dial_switch_id = msg.data[0];
+
+	switch (dial_switch_id) {
+	case DIAL_SWITCH_1:
+		printf("Dial set to switch 1 \n");
+		break;
+	case DIAL_SWITCH_2:
+		printf("Dial set to switch 2 \n");
+		break;
+	case DIAL_SWITCH_3:
+		printf("Dial set to switch 3 \n");
+		break;
+	case DIAL_SWITCH_4:
+		printf("Dial set to switch 4 \n");
+		break;
+	case DIAL_SWITCH_5:
+		printf("Dial set to switch 5 \n");
 		break;
 	}
 }

--- a/Core/Src/steeringio.c
+++ b/Core/Src/steeringio.c
@@ -50,6 +50,9 @@ void buttons_update(can_msg_t msg)
 		printf("Enter button pressed \n");
 		select_nero_index();
 		break;
+	case BUTTON_SPARE:
+		printf("Spare button pressed \n");
+		break;
 	default:
 		break;
 	}

--- a/Core/Src/steeringio.c
+++ b/Core/Src/steeringio.c
@@ -21,6 +21,13 @@ static void right_button_cb()
 	}
 }
 
+static void set_torque_limit_wrapper(float percentage)
+{
+	if (get_func_state() == F_EFFICIENCY) {
+		set_torque_limit(percentage);
+	}
+}
+
 void buttons_update(can_msg_t msg)
 {
 	uint8_t button_id = msg.data[0];
@@ -65,18 +72,23 @@ void dial_update(can_msg_t msg)
 	switch (dial_switch_id) {
 	case DIAL_SWITCH_1:
 		printf("Dial set to switch 1 \n");
+		set_torque_limit_wrapper(0.2);
 		break;
 	case DIAL_SWITCH_2:
 		printf("Dial set to switch 2 \n");
+		set_torque_limit_wrapper(0.4);
 		break;
 	case DIAL_SWITCH_3:
 		printf("Dial set to switch 3 \n");
+		set_torque_limit_wrapper(0.6);
 		break;
 	case DIAL_SWITCH_4:
 		printf("Dial set to switch 4 \n");
+		set_torque_limit_wrapper(0.8);
 		break;
 	case DIAL_SWITCH_5:
 		printf("Dial set to switch 5 \n");
+		set_torque_limit_wrapper(1.0);
 		break;
 	}
 }


### PR DESCRIPTION
## Changes
- Torque dial CAN messages are received in steeringio.c
- When the dial's setting is changed, set_torque_limit() is called. The five settings are: 20%, 40%, 60%, 80%, and 100%.

## Notes
- Not tested yet

## Checklist
- [x] No merge conflicts
- [x] All checks passing
- [x] Assign the PR to yourself
- [ ] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes [#9](https://github.com/Northeastern-Electric-Racing/SteeringWheel24A/issues/9)
