### PR TITLE
Simplify Fuse and Shutdown Reading w/ bitstreams

### DIFF
--- a/Core/Inc/pdu.h
+++ b/Core/Inc/pdu.h
@@ -8,6 +8,8 @@
 #include "INA226.h"
 #include <stdbool.h>
 #include <stdint.h>
+#include "bitstream.h"
+#include "c_utils.h"
 
 typedef struct {
 	I2C_HandleTypeDef *hi2c;
@@ -56,10 +58,10 @@ typedef enum {
  * @brief Read the status of the PDU fuses.
  * 
  * @param pdu Pointer to struct representing the PDU
- * @param status Buffer that fuse data will be written to
+ * @param status Bitstream for storing fuse data
  * @return int8_t Error code resulting from reading GPIO expander pins over I2C or mutex acquisition
  */
-int8_t read_fuses(pdu_t *pdu, bool status[MAX_FUSES]);
+int8_t read_fuses(pdu_t *pdu, bitstream_t* bitstream);
 
 /**
  * @brief Read the state of the TSMS signal.

--- a/Core/Inc/pdu.h
+++ b/Core/Inc/pdu.h
@@ -61,7 +61,7 @@ typedef enum {
  * @param status Bitstream for storing fuse data
  * @return int8_t Error code resulting from reading GPIO expander pins over I2C or mutex acquisition
  */
-int8_t read_fuses(pdu_t *pdu, bitstream_t* bitstream);
+int8_t read_fuses(pdu_t *pdu, bitstream_t *bitstream);
 
 /**
  * @brief Read the state of the TSMS signal.
@@ -93,7 +93,7 @@ typedef enum {
  * @param status Bitstream to store shutdown data
  * @return int8_t Result of reading pins on the shutdown monitor GPIO expander of the PDU or result of mutex acquisition
  */
-int8_t read_shutdown(pdu_t *pdu, bitstream_t* bitstream);
+int8_t read_shutdown(pdu_t *pdu, bitstream_t *bitstream);
 
 /**
  * @brief Read the status of the shutdown loop.
@@ -136,6 +136,10 @@ int8_t read_brake_state(pdu_t *pdu, bool *status);
 #define MUTEX_TIMEOUT	osWaitForever /* ms */
 #define RTDS_DURATION	1750 /* ms at 1kHz tick rate */
 #define SOUND_RTDS_FLAG 1U
+
+/* Extracts the specified bit from a byte. */
+/* Gets the most significant bit first. So, bit 0 is the leftmost bit in the byte. */
+#define EXTRACT_BIT(num, bit) ((num >> (7 - bit)) & 0x01)
 
 // clang-format off
 /* CTRL Expander */

--- a/Core/Inc/pdu.h
+++ b/Core/Inc/pdu.h
@@ -90,10 +90,10 @@ typedef enum {
  * @brief Read the status of the shutdown loop.
  * 
  * @param pdu Pointer to struct representing the PDU
- * @param status Buffer that fuse data will be written to
+ * @param status Bitstream to store shutdown data
  * @return int8_t Result of reading pins on the shutdown monitor GPIO expander of the PDU or result of mutex acquisition
  */
-int8_t read_shutdown(pdu_t *pdu, bool status[MAX_SHUTDOWN_STAGES]);
+int8_t read_shutdown(pdu_t *pdu, bitstream_t* bitstream);
 
 /**
  * @brief Read the status of the shutdown loop.

--- a/Core/Src/monitor.c
+++ b/Core/Src/monitor.c
@@ -335,38 +335,17 @@ void vShutdownMonitor(void *pv_params)
 				   .len = 2,
 				   .data = { 0 } };
 	pdu_t *pdu = (pdu_t *)pv_params;
-	bool shutdown_loop[MAX_SHUTDOWN_STAGES] = { 0 };
-	uint16_t shutdown_buf;
-
-	struct __attribute__((__packed__)) {
-		uint8_t shut_1;
-		uint8_t shut_2;
-	} shutdown_data;
-
 	for (;;) {
-		shutdown_buf = 0;
+		bitstream_t shutdown;
+		uint8_t bitstream_data[2];
+		bitstream_init(&shutdown, bitstream_data, 2);
 
-		if (read_shutdown(pdu, shutdown_loop)) {
+		if (read_shutdown(pdu, &shutdown)) {
 			fault_data.diag = "Failed to read shutdown buffer";
 			queue_fault(&fault_data);
 		}
 
-		for (shutdown_stage_t stage = 0; stage < MAX_SHUTDOWN_STAGES;
-		     stage++) {
-			shutdown_buf |=
-				shutdown_loop[stage]
-				<< stage; /* Sets the bit at position `stage` to the state of the stage */
-		}
-
-		/* seperate each byte */
-		shutdown_data.shut_1 = shutdown_buf & 0xFF;
-		shutdown_data.shut_2 = (shutdown_buf >> 8) & 0xFF;
-
-		// reverse the bit order
-		shutdown_data.shut_1 = reverse_bits(shutdown_data.shut_1);
-		shutdown_data.shut_2 = reverse_bits(shutdown_data.shut_2);
-
-		memcpy(shutdown_msg.data, &shutdown_data, shutdown_msg.len);
+		memcpy(shutdown_msg.data, &shutdown.data, shutdown_msg.len);
 		if (queue_can_msg(shutdown_msg)) {
 			fault_data.diag = "Failed to send CAN message";
 			queue_fault(&fault_data);

--- a/Core/Src/monitor.c
+++ b/Core/Src/monitor.c
@@ -9,6 +9,7 @@
 #include "cerberus_conf.h"
 #include "fault.h"
 #include "state_machine.h"
+#include "bitstream.h"
 
 #define TSMS_DEBOUNCE_PERIOD 500 /* ms */
 
@@ -159,35 +160,14 @@ void read_fuse_data(void *arg)
 	fault_data_t fault_data = { .id = FUSE_MONITOR_FAULT,
 				    .severity = DEFCON5 };
 	can_msg_t fuse_msg = { .id = CANID_FUSE, .len = 2, .data = { 0 } };
-	uint16_t fuse_buf;
-	bool fuses[MAX_FUSES] = { 0 };
 
-	struct __attribute__((__packed__)) {
-		uint8_t fuse_1;
-		uint8_t fuse_2;
-	} fuse_data;
-
-	fuse_buf = 0;
-
-	if (read_fuses(pdu, fuses)) {
+	bitstream_t fuses;
+	if (read_fuses(pdu, &fuses)) {
 		fault_data.diag = "Failed to read fuses";
 		queue_fault(&fault_data);
 	}
 
-	for (fuse_t fuse = 0; fuse < MAX_FUSES; fuse++) {
-		fuse_buf |=
-			fuses[fuse]
-			<< fuse; /* Sets the bit at position `fuse` to the state of the fuse */
-	}
-
-	fuse_data.fuse_1 = fuse_buf & 0xFF;
-	fuse_data.fuse_2 = (fuse_buf >> 8) & 0xFF;
-
-	// reverse the bit order
-	fuse_data.fuse_1 = reverse_bits(fuse_data.fuse_1);
-	fuse_data.fuse_2 = reverse_bits(fuse_data.fuse_2);
-
-	memcpy(fuse_msg.data, &fuse_data, fuse_msg.len);
+	memcpy(fuse_msg.data, &fuses.data, fuse_msg.len);
 	if (queue_can_msg(fuse_msg)) {
 		fault_data.diag = "Failed to send CAN message";
 		queue_fault(&fault_data);

--- a/Core/Src/pdu.c
+++ b/Core/Src/pdu.c
@@ -371,7 +371,7 @@ void read_pump_sensors(pdu_t *pdu, uint32_t pump_sensors_buf[2])
 	       sizeof(pdu->pump_sensors_dma_buf));
 }
 
-int8_t read_fuses(pdu_t *pdu, bitstream_t* bitstream)
+int8_t read_fuses(pdu_t *pdu, bitstream_t *bitstream)
 {
 	if (!pdu)
 		return -1;
@@ -441,7 +441,7 @@ int8_t read_tsms_sense(pdu_t *pdu, bool *status)
 	return 0;
 }
 
-int8_t read_shutdown(pdu_t *pdu, bitstream_t* bitstream)
+int8_t read_shutdown(pdu_t *pdu, bitstream_t *bitstream)
 {
 	if (!pdu)
 		return -1;

--- a/Core/Src/pdu.c
+++ b/Core/Src/pdu.c
@@ -281,13 +281,6 @@ void read_pump_sensors(pdu_t *pdu, uint32_t pump_sensors_buf[2])
 	       sizeof(pdu->pump_sensors_dma_buf));
 }
 
-static void deconstruct_buf(uint8_t data, bool config[8])
-{
-	for (uint8_t i = 0; i < 8; i++) {
-		config[i] = (data >> i) & 1;
-	}
-}
-
 int8_t read_fuses(pdu_t *pdu, bitstream_t* bitstream)
 {
 	// clang-format off
@@ -358,7 +351,7 @@ int8_t read_tsms_sense(pdu_t *pdu, bool *status)
 	return 0;
 }
 
-int8_t read_shutdown(pdu_t *pdu, bool status[MAX_SHUTDOWN_STAGES])
+int8_t read_shutdown(pdu_t *pdu, bitstream_t* bitstream)
 {
 	if (!pdu)
 		return -1;

--- a/Core/Src/pdu.c
+++ b/Core/Src/pdu.c
@@ -288,8 +288,9 @@ static void deconstruct_buf(uint8_t data, bool config[8])
 	}
 }
 
-int8_t read_fuses(pdu_t *pdu, bool status[MAX_FUSES])
+int8_t read_fuses(pdu_t *pdu, bitstream_t* bitstream)
 {
+	// clang-format off
 	if (!pdu)
 		return -1;
 
@@ -312,25 +313,25 @@ int8_t read_fuses(pdu_t *pdu, bool status[MAX_FUSES])
 		return error;
 	}
 
-	bool bank0[8];
-	deconstruct_buf(bank0_d, bank0);
+	bitstream_t fuses;
+	uint8_t fuse_data[2];
+	bitstream_init(&fuses, fuse_data, 2);
 
-	bool bank1[8];
-	deconstruct_buf(bank1_d, bank1);
-
-	status[PUMP_FUSE_STAT0] = bank0[PIN_PUMP_FUSE_STAT0];
-	status[SD_TO_BRB_FUSE] = bank0[PIN_SD_TO_BRB_FUSE_STAT];
-	status[LV_BOARDS_FUSE_STAT] = bank1[PIN_LV_BOARDS_FUSE_STAT];
-	status[RADFAN_FUSE_STAT] = bank1[PIN_RADFAN_FUSE_STAT];
-	status[BATTBOX_FUSE_STAT] = bank1[PIN_BATTBOX_FUSE_STAT];
-	status[BUCK_FUSE_STAT] = bank1[PIN_BUCK_FUSE_STAT];
-	status[FANBATTBOX_STAT] = bank1[PIN_FANBATTBOX_STAT];
-	status[PUMP_FUSE_STAT1] = bank1[PIN_PUMP_FUSE_STAT1];
-	status[DASHBOARD_FUSE_STAT] = bank1[PIN_DASHBOARD_FUSE_STAT];
-	status[BRKLIGHT_FUSE_STAT] = bank1[PIN_BRKLIGHT_FUSE_STAT];
+	bitstream_add(&fuses, NER_GET_BIT(bank0_d, PIN_PUMP_FUSE_STAT0), 1); 		// Read Pin P00
+	bitstream_add(&fuses, NER_GET_BIT(bank0_d, PIN_SD_TO_BRB_FUSE_STAT), 1); 	// Read Pin P02
+	bitstream_add(&fuses, NER_GET_BIT(bank1_d, PIN_LV_BOARDS_FUSE_STAT), 1); 	// Read Pin P10
+	bitstream_add(&fuses, NER_GET_BIT(bank1_d, PIN_RADFAN_FUSE_STAT), 1); 		// Read Pin P11
+	bitstream_add(&fuses, NER_GET_BIT(bank1_d, PIN_BATTBOX_FUSE_STAT), 1); 		// Read Pin P12
+	bitstream_add(&fuses, NER_GET_BIT(bank1_d, PIN_BUCK_FUSE_STAT), 1); 		// Read Pin P13
+	bitstream_add(&fuses, NER_GET_BIT(bank1_d, PIN_FANBATTBOX_STAT), 1); 		// Read Pin P14
+	bitstream_add(&fuses, NER_GET_BIT(bank1_d, PIN_PUMP_FUSE_STAT1), 1); 		// Read Pin P15
+	bitstream_add(&fuses, NER_GET_BIT(bank0_d, PIN_DASHBOARD_FUSE_STAT), 1); 	// Read Pin P16
+	bitstream_add(&fuses, NER_GET_BIT(bank0_d, PIN_BRKLIGHT_FUSE_STAT), 1); 	// Read Pin P17
+	bitstream_add(&fuses, 0, 6); 												// Extra (6 bits)
 
 	osMutexRelease(pdu->mutex);
 	return 0;
+	// clang-format on
 }
 
 int8_t read_tsms_sense(pdu_t *pdu, bool *status)

--- a/Core/Src/pdu.c
+++ b/Core/Src/pdu.c
@@ -382,22 +382,20 @@ int8_t read_shutdown(pdu_t *pdu, bool status[MAX_SHUTDOWN_STAGES])
 		return error;
 	}
 
-	bool bank0[8];
-	deconstruct_buf(bank0_d, bank0);
+	bitstream_t shutdown;
+	uint8_t shutdown_data[2];
+	bitstream_init(&shutdown, shutdown_data, 2);
 
-	bool bank1[8];
-	deconstruct_buf(bank1_d, bank1);
-
-	status[HVD_GOOD] = bank0[PIN_HVD_GOOD];
-	status[HVC_GOOD] = bank0[PIN_HVC_GOOD];
-	status[BOTS_GOOD] = bank0[PIN_BOTS_GOOD];
-	status[CKPT_BRB] = bank0[PIN_CKPT_BRB];
-	status[BMS_GOOD] = bank0[PIN_BMS_GOOD];
-	status[INERTIA_SW_GOOD] = bank0[PIN_INERTIA_SW_GOOD];
-	status[SPARE_GPIO0] = bank0[PIN_SPARE_GPIO0];
-	status[IMD_GOOD] = bank0[PIN_IMD_GOOD];
-
-	status[BSPD_GOOD] = bank1[PIN_BSPD_GOOD];
+	bitstream_add(&shutdown, NER_GET_BIT(bank0_d, PIN_HVD_GOOD), 1); 			// Read Pin P00
+	bitstream_add(&shutdown, NER_GET_BIT(bank0_d, PIN_HVC_GOOD), 1); 			// Read Pin P01
+	bitstream_add(&shutdown, NER_GET_BIT(bank0_d, PIN_BOTS_GOOD), 1); 			// Read Pin P02
+	bitstream_add(&shutdown, NER_GET_BIT(bank0_d, PIN_CKPT_BRB), 1); 			// Read Pin P03
+	bitstream_add(&shutdown, NER_GET_BIT(bank0_d, PIN_BMS_GOOD), 1); 			// Read Pin P04
+	bitstream_add(&shutdown, NER_GET_BIT(bank0_d, PIN_INERTIA_SW_GOOD), 1); 	// Read Pin P05
+	bitstream_add(&shutdown, NER_GET_BIT(bank0_d, PIN_SPARE_GPIO0), 1); 		// Read Pin P06
+	bitstream_add(&shutdown, NER_GET_BIT(bank0_d, PIN_IMD_GOOD), 1); 			// Read Pin P07
+	bitstream_add(&shutdown, NER_GET_BIT(bank1_d, PIN_BSPD_GOOD), 1); 			// Read Pin P12
+	bitstream_add(&shutdown, 0, 7); 											// Extra (7 bits)
 
 	osMutexRelease(pdu->mutex);
 	return 0;

--- a/Core/Src/pdu.c
+++ b/Core/Src/pdu.c
@@ -373,7 +373,6 @@ void read_pump_sensors(pdu_t *pdu, uint32_t pump_sensors_buf[2])
 
 int8_t read_fuses(pdu_t *pdu, bitstream_t* bitstream)
 {
-	// clang-format off
 	if (!pdu)
 		return -1;
 
@@ -400,21 +399,22 @@ int8_t read_fuses(pdu_t *pdu, bitstream_t* bitstream)
 	uint8_t fuse_data[2];
 	bitstream_init(&fuses, fuse_data, 2);
 
-	bitstream_add(&fuses, NER_GET_BIT(bank0_d, PIN_PUMP_FUSE_STAT0), 1); 		// Read Pin P00
-	bitstream_add(&fuses, NER_GET_BIT(bank0_d, PIN_SD_TO_BRB_FUSE_STAT), 1); 	// Read Pin P02
-	bitstream_add(&fuses, NER_GET_BIT(bank1_d, PIN_LV_BOARDS_FUSE_STAT), 1); 	// Read Pin P10
-	bitstream_add(&fuses, NER_GET_BIT(bank1_d, PIN_RADFAN_FUSE_STAT), 1); 		// Read Pin P11
-	bitstream_add(&fuses, NER_GET_BIT(bank1_d, PIN_BATTBOX_FUSE_STAT), 1); 		// Read Pin P12
-	bitstream_add(&fuses, NER_GET_BIT(bank1_d, PIN_BUCK_FUSE_STAT), 1); 		// Read Pin P13
-	bitstream_add(&fuses, NER_GET_BIT(bank1_d, PIN_FANBATTBOX_STAT), 1); 		// Read Pin P14
-	bitstream_add(&fuses, NER_GET_BIT(bank1_d, PIN_PUMP_FUSE_STAT1), 1); 		// Read Pin P15
-	bitstream_add(&fuses, NER_GET_BIT(bank0_d, PIN_DASHBOARD_FUSE_STAT), 1); 	// Read Pin P16
-	bitstream_add(&fuses, NER_GET_BIT(bank0_d, PIN_BRKLIGHT_FUSE_STAT), 1); 	// Read Pin P17
+	// clang-format off
+	bitstream_add(&fuses, EXTRACT_BIT(bank0_d, PIN_PUMP_FUSE_STAT0), 1); 		// Read Pin P00
+	bitstream_add(&fuses, EXTRACT_BIT(bank0_d, PIN_SD_TO_BRB_FUSE_STAT), 1); 	// Read Pin P02
+	bitstream_add(&fuses, EXTRACT_BIT(bank1_d, PIN_LV_BOARDS_FUSE_STAT), 1); 	// Read Pin P10
+	bitstream_add(&fuses, EXTRACT_BIT(bank1_d, PIN_RADFAN_FUSE_STAT), 1); 		// Read Pin P11
+	bitstream_add(&fuses, EXTRACT_BIT(bank1_d, PIN_BATTBOX_FUSE_STAT), 1); 		// Read Pin P12
+	bitstream_add(&fuses, EXTRACT_BIT(bank1_d, PIN_BUCK_FUSE_STAT), 1); 		// Read Pin P13
+	bitstream_add(&fuses, EXTRACT_BIT(bank1_d, PIN_FANBATTBOX_STAT), 1); 		// Read Pin P14
+	bitstream_add(&fuses, EXTRACT_BIT(bank1_d, PIN_PUMP_FUSE_STAT1), 1); 		// Read Pin P15
+	bitstream_add(&fuses, EXTRACT_BIT(bank0_d, PIN_DASHBOARD_FUSE_STAT), 1); 	// Read Pin P16
+	bitstream_add(&fuses, EXTRACT_BIT(bank0_d, PIN_BRKLIGHT_FUSE_STAT), 1); 	// Read Pin P17
 	bitstream_add(&fuses, 0, 6); 												// Extra (6 bits)
+	// clang-format on
 
 	osMutexRelease(pdu->mutex);
 	return 0;
-	// clang-format on
 }
 
 int8_t read_tsms_sense(pdu_t *pdu, bool *status)
@@ -465,20 +465,22 @@ int8_t read_shutdown(pdu_t *pdu, bitstream_t* bitstream)
 		return error;
 	}
 
+	// clang-format off
 	bitstream_t shutdown;
 	uint8_t shutdown_data[2];
 	bitstream_init(&shutdown, shutdown_data, 2);
 
-	bitstream_add(&shutdown, NER_GET_BIT(bank0_d, PIN_HVD_GOOD), 1); 			// Read Pin P00
-	bitstream_add(&shutdown, NER_GET_BIT(bank0_d, PIN_HVC_GOOD), 1); 			// Read Pin P01
-	bitstream_add(&shutdown, NER_GET_BIT(bank0_d, PIN_BOTS_GOOD), 1); 			// Read Pin P02
-	bitstream_add(&shutdown, NER_GET_BIT(bank0_d, PIN_CKPT_BRB), 1); 			// Read Pin P03
-	bitstream_add(&shutdown, NER_GET_BIT(bank0_d, PIN_BMS_GOOD), 1); 			// Read Pin P04
-	bitstream_add(&shutdown, NER_GET_BIT(bank0_d, PIN_INERTIA_SW_GOOD), 1); 	// Read Pin P05
-	bitstream_add(&shutdown, NER_GET_BIT(bank0_d, PIN_SPARE_GPIO0), 1); 		// Read Pin P06
-	bitstream_add(&shutdown, NER_GET_BIT(bank0_d, PIN_IMD_GOOD), 1); 			// Read Pin P07
-	bitstream_add(&shutdown, NER_GET_BIT(bank1_d, PIN_BSPD_GOOD), 1); 			// Read Pin P12
+	bitstream_add(&shutdown, EXTRACT_BIT(bank0_d, PIN_HVD_GOOD), 1); 			// Read Pin P00
+	bitstream_add(&shutdown, EXTRACT_BIT(bank0_d, PIN_HVC_GOOD), 1); 			// Read Pin P01
+	bitstream_add(&shutdown, EXTRACT_BIT(bank0_d, PIN_BOTS_GOOD), 1); 			// Read Pin P02
+	bitstream_add(&shutdown, EXTRACT_BIT(bank0_d, PIN_CKPT_BRB), 1); 			// Read Pin P03
+	bitstream_add(&shutdown, EXTRACT_BIT(bank0_d, PIN_BMS_GOOD), 1); 			// Read Pin P04
+	bitstream_add(&shutdown, EXTRACT_BIT(bank0_d, PIN_INERTIA_SW_GOOD), 1); 	// Read Pin P05
+	bitstream_add(&shutdown, EXTRACT_BIT(bank0_d, PIN_SPARE_GPIO0), 1); 		// Read Pin P06
+	bitstream_add(&shutdown, EXTRACT_BIT(bank0_d, PIN_IMD_GOOD), 1); 			// Read Pin P07
+	bitstream_add(&shutdown, EXTRACT_BIT(bank1_d, PIN_BSPD_GOOD), 1); 			// Read Pin P12
 	bitstream_add(&shutdown, 0, 7); 											// Extra (7 bits)
+	// clang-format on
 
 	osMutexRelease(pdu->mutex);
 	return 0;

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ Drivers/Embedded-Base/general/src/pi4ioe.c \
 Drivers/Embedded-Base/general/src/pca9539.c \
 Drivers/Embedded-Base/middleware/src/timer.c \
 Drivers/Embedded-Base/middleware/src/ringbuffer.c \
+Drivers/Embedded-Base/middleware/src/bitstream.c \
 Drivers/Embedded-Base/middleware/src/c_utils.c \
 Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_adc.c \
 Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_adc_ex.c \


### PR DESCRIPTION
## Changes
Current fuse/shutdown reading functions in pdu.c seem unnecessarily complicated. Since pca9539_read_reg() already reads all of the pins on the GPIO expander, it seems convenient to read both banks, extract the desired bits, and add them to a bitstream to send over CAN.

## Notes
Not tested yet

## Checklist
- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [ ] Request reviewers & ping on Slack