### PR TITLE
Extended CAN IDs

### DIFF
--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -66,8 +66,14 @@ void can1_callback(CAN_HandleTypeDef *hcan)
 	}
 
 	new_msg.len = rx_header.DLC;
-	new_msg.id = rx_header.StdId;
-
+	(rx_header.StdId == 0) ?
+		(new_msg.id = rx_header.ExtId) :
+		(new_msg.id_is_extended =
+			 true); // If the messsage has an extended CAN ID, save the message accordingly.
+	(rx_header.ExtId == 0) ?
+		(new_msg.id = rx_header.StdId) :
+		(new_msg.id_is_extended =
+			 false); // If the message has a standard CAN ID, save the message accordingly.
 	queue_and_set_flag(can_inbound_queue, &new_msg, can_receive_thread,
 			   NEW_CAN_MSG_FLAG);
 }


### PR DESCRIPTION
## Changes
Add support for extended CAN IDs by implementing the changes in this [Embedded Base PR](https://github.com/Northeastern-Electric-Racing/Embedded-Base/pull/255). Messages with extended CAN IDs can now be sent using `can_send_msg` (by modifying the `id_is_extended` bool in the struct. Messages with extended CAN IDs can also be received, due to changes in can_handler.c.

## Notes
AFAIK there aren't currently any extended CAN IDs in Cerberus, so I didn't modify any of the messages. The `id_is_extended` bool is obv default by false, so it can be ignored for messages with standard ids.

Also haven't tested yet

## Checklist
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Assign the PR to yourself
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #290
