### PR TITLE
Pumps CAN Message Edits

### DIFF
--- a/Core/Inc/pdu.h
+++ b/Core/Inc/pdu.h
@@ -142,6 +142,13 @@ int8_t read_brake_state(pdu_t *pdu, bool *status);
 /* Gets the most significant bit first. So, bit 0 is the leftmost bit in the byte. */
 #define EXTRACT_BIT(num, bit) ((num >> (7 - bit)) & 0x01)
 
+/* Function that approximates the pump sensor temperature. Takes in resistance and outputs temperature. */
+// (Created based on "GE Series RvT" PDU Altium table)
+#define PUMP_TEMP_APPROX(R)                                      \
+	(-0.1102 * pow(log(R), 3)) + (4.6521 * pow(log(R), 2)) - \
+		(80.47 * log(R)) +                               \
+		457.6 // f(x) = -0.1102ln(x)^3 + 4.6521ln(x)^2 - 80.47ln(x) + 457.6
+
 /* GPIO Expander Reset Pins */
 #define CTRL_RESET_PIN	   GPIO_PIN_6
 #define SHUTDOWN_RESET_PIN GPIO_PIN_7

--- a/Core/Src/monitor.c
+++ b/Core/Src/monitor.c
@@ -27,23 +27,36 @@ void read_pump_sens(pdu_t *pdu)
 				    .severity = DEFCON5 };
 	can_msg_t msg = { .id = CANID_PUMP_SENSORS, .len = 8, .data = { 0 } };
 
-	uint16_t pump_volts_int[2];
+	uint16_t buffer[2];
 
-	read_pump_sensors(pdu, pump_volts_int);
+	read_pump_sensors(pdu, buffer);
 
-	// convert to real voltage
-	float pump_sensor0_volts_real = (pump_volts_int[0] / 4095.0) * 3.3;
-	float pump_sensor1_volts_real = (pump_volts_int[1] / 4095.0) * 3.3;
+	struct __attribute__((__packed__)) {
+		uint16_t pump0_voltage;
+		uint16_t pump1_voltage;
+		int16_t pump0_temp;
+		int16_t pump1_temp;
+	} pump_data;
 
-	pump_volts_int[0] = (uint32_t)(pump_sensor0_volts_real * 10000);
-	pump_volts_int[1] = (uint32_t)(pump_sensor1_volts_real * 10000);
+	/* Determine real voltage values */
+	float pump0_voltage_real = (buffer[0] / 4095.0) * 3.3;
+	float pump1_voltage_real = (buffer[1] / 4095.0) * 3.3;
 
-	uint32_t pump_volts_int_new[2] = {
-		(uint32_t)(pump_sensor0_volts_real * 10000),
-		(uint32_t)(pump_sensor1_volts_real * 10000)
-	};
+	/* Determine real temperature values */
+	float r_pump0 =
+		(pump0_voltage_real / (3.3 - pump_data.pump0_voltage)) * 10000;
+	float r_pump1 =
+		(pump1_voltage_real / (3.3 - pump_data.pump1_voltage)) * 10000;
+	int16_t temp_pump0 = PUMP_TEMP_APPROX(r_pump0);
+	int16_t temp_pump1 = PUMP_TEMP_APPROX(r_pump1);
 
-	memcpy(msg.data, pump_volts_int_new, msg.len);
+	/* Convert to int and store in struct */
+	pump_data.pump0_voltage = pump0_voltage_real * 1000;
+	pump_data.pump1_voltage = pump1_voltage_real * 1000;
+	pump_data.pump0_voltage = (int16_t)roundf(temp_pump0);
+	pump_data.pump1_voltage = (int16_t)roundf(temp_pump1);
+
+	memcpy(msg.data, &pump_data, msg.len);
 	if (queue_can_msg(msg)) {
 		fault_data.diag = "Failed to send pump sensor CAN message";
 		queue_fault(&fault_data);


### PR DESCRIPTION
## Changes
- Added temp calculation to pumps CAN message

Message is now structured like:
Pump 0 Voltage (16 bits)
Pump 1 Voltage (16 bits)
Pump 0 Temp (16 bits)
Pump 1 Temp (16 bits)

## Notes
Temps are rounded to ints because that was the resolution of the temp data in the [table](https://northeastern-fsae.365.altium.com/designs/4D75E2FC-E56D-4FCE-AB1F-8D36BCF48396?variant=[No+Variations]&activeView=SCH&activeDocumentId=02_PDU_24A_R2_CONN.SchDoc(2)&location=[1,378.29,-4878.75,-598.45]#design) used to create the approximation

Also not tested yet

## Checklist
- [x] No merge conflicts
- [x] All checks passing
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack