### PR TITLE
Allow queuing priority messages in CAN

### DIFF
--- a/Core/Inc/can_handler.h
+++ b/Core/Inc/can_handler.h
@@ -24,6 +24,14 @@ void can1_callback(CAN_HandleTypeDef *hcan);
 int8_t queue_can_msg(can_msg_t msg);
 
 /**
+ * @brief Place a CAN message in a queue at a high priority.
+ * 
+ * @param msg CAN message to be sent.
+ * @return int8_t Error code.
+ */
+int8_t queue_prio_can_msg(can_msg_t msg);
+
+/**
  * @brief Initialize CAN line 1.
  * 
  * @param hcan Pointer to struct representing CAN hardware.

--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -101,8 +101,8 @@ int8_t queue_prio_can_msg(can_msg_t msg) {
 	if (!can_outbound_queue) { return -1; }
 
 	/* Set the priority flag to 1U (Higher number = higher priority) */
-	osStatus_t status = osMessageQueuePut(queue, msg_ptr, 1U, 0U);
-	osThreadFlagsSet(thread_id, flags);
+	osStatus_t status = osMessageQueuePut(can_outbound_queue, msg, 1U, 0U);
+	osThreadFlagsSet(can_dispatch_handle, CAN_DISPATCH_FLAG);
 	return status;
 }
 

--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -96,6 +96,16 @@ int8_t queue_can_msg(can_msg_t msg)
 				  CAN_DISPATCH_FLAG);
 }
 
+/* TODO: Find what queue_and_set_flag (in embedded base) is used in, then change to support prio */
+int8_t queue_prio_can_msg(can_msg_t msg) {
+	if (!can_outbound_queue) { return -1; }
+
+	/* Set the priority flag to 1U (Higher number = higher priority) */
+	osStatus_t status = osMessageQueuePut(queue, msg_ptr, 1U, 0U);
+	osThreadFlagsSet(thread_id, flags);
+	return status;
+}
+
 osThreadId_t can_dispatch_handle;
 const osThreadAttr_t can_dispatch_attributes = {
 	.name = "CanDispatch",

--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -103,7 +103,7 @@ int8_t queue_prio_can_msg(can_msg_t msg)
 		return -1;
 
 	/* Set the priority flag to 1U (Higher number = higher priority) */
-	osStatus_t status = osMessageQueuePut(can_outbound_queue, msg, 1U, 0U);
+	osStatus_t status = osMessageQueuePut(can_outbound_queue, &msg, 1U, 0U);
 	osThreadFlagsSet(can_dispatch_handle, CAN_DISPATCH_FLAG);
 	return status;
 }

--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -98,7 +98,9 @@ int8_t queue_can_msg(can_msg_t msg)
 
 /* TODO: Find what queue_and_set_flag (in embedded base) is used in, then change to support prio */
 int8_t queue_prio_can_msg(can_msg_t msg) {
-	if (!can_outbound_queue) { return -1; }
+	if (!can_outbound_queue) { 
+		return -1; 
+	}
 
 	/* Set the priority flag to 1U (Higher number = higher priority) */
 	osStatus_t status = osMessageQueuePut(can_outbound_queue, msg, 1U, 0U);

--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -97,7 +97,8 @@ int8_t queue_can_msg(can_msg_t msg)
 }
 
 /* TODO: Find what queue_and_set_flag (in embedded base) is used in, then change to support prio */
-int8_t queue_prio_can_msg(can_msg_t msg) {
+int8_t queue_prio_can_msg(can_msg_t msg)
+{
 	if (!can_outbound_queue)
 		return -1;
 

--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -98,9 +98,8 @@ int8_t queue_can_msg(can_msg_t msg)
 
 /* TODO: Find what queue_and_set_flag (in embedded base) is used in, then change to support prio */
 int8_t queue_prio_can_msg(can_msg_t msg) {
-	if (!can_outbound_queue) { 
-		return -1; 
-	}
+	if (!can_outbound_queue)
+		return -1;
 
 	/* Set the priority flag to 1U (Higher number = higher priority) */
 	osStatus_t status = osMessageQueuePut(can_outbound_queue, msg, 1U, 0U);

--- a/Core/Src/dti.c
+++ b/Core/Src/dti.c
@@ -131,7 +131,7 @@ void dti_send_brake_current(uint16_t brake_current)
 
 	/* Send CAN message */
 	memcpy(&msg.data, &brake_current, 2);
-	queue_can_msg(msg);
+	queue_prio_can_msg(msg);
 }
 
 void dti_set_speed(int32_t rpm)
@@ -145,7 +145,7 @@ void dti_set_speed(int32_t rpm)
 
 	/* Send CAN message */
 	memcpy(msg.data, &rpm, msg.len);
-	queue_can_msg(msg);
+	queue_prio_can_msg(msg);
 }
 
 void dti_set_position(int16_t angle)
@@ -157,7 +157,7 @@ void dti_set_position(int16_t angle)
 
 	/* Send CAN message */
 	memcpy(msg.data, &angle, msg.len);
-	queue_can_msg(msg);
+	queue_prio_can_msg(msg);
 }
 
 void dti_set_relative_current(int16_t relative_current)
@@ -169,7 +169,7 @@ void dti_set_relative_current(int16_t relative_current)
 
 	/* Send CAN message */
 	memcpy(msg.data, &relative_current, msg.len);
-	queue_can_msg(msg);
+	queue_prio_can_msg(msg);
 }
 
 void dti_set_relative_brake_current(int16_t relative_brake_current)
@@ -181,7 +181,7 @@ void dti_set_relative_brake_current(int16_t relative_brake_current)
 
 	/* Send CAN message */
 	memcpy(msg.data, &relative_brake_current, msg.len);
-	queue_can_msg(msg);
+	queue_prio_can_msg(msg);
 }
 
 void dti_set_digital_output(uint8_t output, bool value)
@@ -192,7 +192,7 @@ void dti_set_digital_output(uint8_t output, bool value)
 
 	/* Send CAN message */
 	memcpy(msg.data, &ctrl, msg.len);
-	queue_can_msg(msg);
+	queue_prio_can_msg(msg);
 }
 
 void dti_set_max_ac_current(int16_t current)
@@ -204,7 +204,7 @@ void dti_set_max_ac_current(int16_t current)
 
 	/* Send CAN message */
 	memcpy(msg.data, &current, msg.len);
-	queue_can_msg(msg);
+	queue_prio_can_msg(msg);
 }
 
 void dti_set_max_ac_brake_current(int16_t current)
@@ -216,7 +216,7 @@ void dti_set_max_ac_brake_current(int16_t current)
 
 	/* Send CAN message */
 	memcpy(msg.data, &current, msg.len);
-	queue_can_msg(msg);
+	queue_prio_can_msg(msg);
 }
 
 void dti_set_max_dc_current(int16_t current)
@@ -228,7 +228,7 @@ void dti_set_max_dc_current(int16_t current)
 
 	/* Send CAN message */
 	memcpy(msg.data, &current, msg.len);
-	queue_can_msg(msg);
+	queue_prio_can_msg(msg);
 }
 
 void dti_set_max_dc_brake_current(int16_t current)
@@ -240,7 +240,7 @@ void dti_set_max_dc_brake_current(int16_t current)
 
 	/* Send CAN message */
 	memcpy(msg.data, &current, msg.len);
-	queue_can_msg(msg);
+	queue_prio_can_msg(msg);
 }
 
 void dti_set_drive_enable(bool drive_enable)
@@ -249,7 +249,7 @@ void dti_set_drive_enable(bool drive_enable)
 
 	/* Send CAN message */
 	memcpy(msg.data, &drive_enable, msg.len);
-	queue_can_msg(msg);
+	queue_prio_can_msg(msg);
 }
 
 int32_t dti_get_rpm(dti_t *mc)


### PR DESCRIPTION
## Changes

Added a `int8_t queue_prio_can_msg(can_msg_t msg)`

## Notes

This function is NOT dependent upon `queue_and_set_flags`, but contains the same code. If we wanted to add a priority param to `queue_and_set_flags`, we could consolidate code. We could also add a priority param to `queue_can_message`, but I would advise against it as `queue_can_message` is already significantly used and we only want to distinguish between "priority" and "not piority"

## Test Cases

- Queue a regular message and a priority message, then receive
- Queue a priority message and a regular message, then receive
- Queue 100 regular messages and 10 priority messages, then receive
- Queue 2 regular messages and receive
- Queue 2 priority messages and receive

## To Do

- [ ] Change `queue_and_set_flags` in Embedded Base (optional)
- [ ] Actually integrate use of `queue_prio_can_message`

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please reach out to your Project Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes Northeastern-Electric-Racing/Cerberus-2.0#120
