### PR TITLE
Battbox Fan Control

### DIFF
--- a/Core/Inc/bms.h
+++ b/Core/Inc/bms.h
@@ -25,9 +25,14 @@ typedef struct {
 
 /*
 * @brief Initializes the BMS struct and mutex
+*/
+void bms_init();
+
+/*
+* @brief Gets the BMS struct
 * @return Pointer to the BMS struct
 */
-bms_t *bms_init();
+bms_t *bms_get();
 
 /*
 * @brief Gets the current battery box temperature

--- a/Core/Inc/bms.h
+++ b/Core/Inc/bms.h
@@ -13,11 +13,6 @@
  */
 void handle_dcl_msg();
 
-/**
- * @brief initializes bms timer
- */
-void init_bms();
-
 typedef struct {
 	uint16_t battbox_temp;
 	osMutexId_t *mutex;

--- a/Core/Inc/bms.h
+++ b/Core/Inc/bms.h
@@ -2,6 +2,9 @@
 #define BMS_H
 
 #include "cmsis_os.h"
+#include "can.h"
+
+#define BMS_CANID_CELL_TEMPS 0x84 /* BMS CELL TEMPERATURES */
 
 #define BMS_DCL_MSG 0x156 /* BMS MONITOR WATCHDOG */
 
@@ -14,5 +17,28 @@ void handle_dcl_msg();
  * @brief initializes bms timer
  */
 void init_bms();
+
+typedef struct {
+	uint16_t battbox_temp;
+	osMutexId_t *mutex;
+} bms_t;
+
+/*
+* @brief Initializes the BMS struct and mutex
+* @return Pointer to the BMS struct
+*/
+bms_t *bms_init();
+
+/*
+* @brief Gets the current battery box temperature
+* @return Battery box temperature (degrees Celsius)
+*/
+uint16_t bms_get_battbox_temp();
+
+/*
+ * @brief Gets the current battery box temperature
+ * @return int32_t Battery box temperature
+ */
+void bms_record_battbox_temp(can_msg_t msg);
 
 #endif /*BMS_H*/

--- a/Core/Inc/bms.h
+++ b/Core/Inc/bms.h
@@ -24,12 +24,6 @@ typedef struct {
 void bms_init();
 
 /*
-* @brief Gets the BMS struct
-* @return Pointer to the BMS struct
-*/
-bms_t *bms_get();
-
-/*
 * @brief Gets the current battery box temperature
 * @return Battery box temperature (degrees Celsius)
 */

--- a/Core/Inc/bms.h
+++ b/Core/Inc/bms.h
@@ -24,10 +24,10 @@ typedef struct {
 void bms_init();
 
 /*
-* @brief Gets the current battery box temperature
-* @return Battery box temperature (degrees Celsius)
+* @brief Sets the current battery box temperature to the passed in variable
+* @returns Failed status if could not acquire mutex, ok otherwise
 */
-uint16_t bms_get_battbox_temp();
+osStatus_t bms_get_battbox_temp(uint16_t *temp);
 
 /*
  * @brief Gets the current battery box temperature

--- a/Core/Inc/control.h
+++ b/Core/Inc/control.h
@@ -14,6 +14,7 @@
 #include "debounce.h"
 #include "dti.h"
 #include "pdu.h"
+#include "bms.h"
 
 #define CONTROL_CANID_FANBATTBOX 0x4A1
 #define CONTROL_CANID_PUMP	 0x4A0
@@ -31,6 +32,9 @@
 
 #define RADFAN_UPPER_CONTROLLER_TEMP 50
 #define RADFAN_LOWER_CONTROLLER_TEMP 30
+
+#define FANBATTBOX_UPPER_TEMP 50
+#define FANBATTBOX_LOWER_TEMP 30
 
 extern osThreadId_t control_handle;
 extern const osThreadAttr_t control_attributes;

--- a/Core/Src/bms.c
+++ b/Core/Src/bms.c
@@ -34,11 +34,6 @@ void bms_init()
 	assert(&bms);
 }
 
-bms_t *bms_get()
-{
-	return &bms;
-}
-
 void handle_dcl_msg()
 {
 	osTimerStart(bms_timer, BMS_CAN_MONITOR_DELAY);

--- a/Core/Src/bms.c
+++ b/Core/Src/bms.c
@@ -22,10 +22,8 @@ static void bms_fault_callback(void *args)
 	queue_fault(&fault_data);
 }
 
-bms_t *bms_init()
+void bms_init()
 {
-	assert(&bms);
-
 	bms.mutex = osMutexNew(&bms_mutex_attributes);
 	assert(bms.mutex);
 
@@ -33,6 +31,11 @@ bms_t *bms_init()
 
 	bms_timer = osTimerNew(bms_fault_callback, osTimerOnce, NULL, NULL);
 
+	assert(&bms);
+}
+
+bms_t *bms_get()
+{
 	return &bms;
 }
 

--- a/Core/Src/bms.c
+++ b/Core/Src/bms.c
@@ -3,6 +3,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "cerberus_conf.h"
 #include "fault.h"
@@ -39,14 +40,13 @@ void handle_dcl_msg()
 	osTimerStart(bms_timer, BMS_CAN_MONITOR_DELAY);
 }
 
-uint16_t bms_get_battbox_temp()
+osStatus_t bms_get_battbox_temp(uint16_t *temp)
 {
-	int16_t temp;
-	osMutexAcquire(bms.mutex, osWaitForever);
-	temp = bms.battbox_temp;
-	osMutexRelease(bms.mutex);
-
-	return temp;
+	osStatus_t stat = osMutexAcquire(bms.mutex, osWaitForever);
+	if (stat)
+		return stat;
+	memcpy(temp, &bms.battbox_temp, sizeof(bms.battbox_temp));
+	return osMutexRelease(bms.mutex);
 }
 
 void bms_record_battbox_temp(can_msg_t msg)

--- a/Core/Src/bms.c
+++ b/Core/Src/bms.c
@@ -9,6 +9,9 @@
 
 osTimerId bms_timer;
 
+static osMutexAttr_t bms_mutex_attributes;
+static bms_t bms;
+
 static void bms_fault_callback(void *args)
 {
 	fault_data_t fault_data = {
@@ -19,12 +22,40 @@ static void bms_fault_callback(void *args)
 	queue_fault(&fault_data);
 }
 
-void init_bms()
+bms_t *bms_init()
 {
+	assert(&bms);
+
+	bms.mutex = osMutexNew(&bms_mutex_attributes);
+	assert(bms.mutex);
+
+	bms.battbox_temp = 0;
+
 	bms_timer = osTimerNew(bms_fault_callback, osTimerOnce, NULL, NULL);
+
+	return &bms;
 }
 
 void handle_dcl_msg()
 {
 	osTimerStart(bms_timer, BMS_CAN_MONITOR_DELAY);
+}
+
+uint16_t bms_get_battbox_temp()
+{
+	int16_t temp;
+	osMutexAcquire(bms.mutex, osWaitForever);
+	temp = bms.battbox_temp;
+	osMutexRelease(bms.mutex);
+
+	return temp;
+}
+
+void bms_record_battbox_temp(can_msg_t msg)
+{
+	osMutexAcquire(bms.mutex, osWaitForever);
+	bms.battbox_temp =
+		(msg.data[0] << 8) +
+		msg.data[1]; // Get "BMS/Cells/Temp_High_Value" (first two bytes of the "Cell Temperatures" CAN message)
+	osMutexRelease(bms.mutex);
 }

--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -33,6 +33,8 @@ static uint16_t id_list_1[4] = {
 static uint16_t id_list_2[4] = { DIAL_CANID_IO, CONTROL_CANID_FANBATTBOX,
 				 CONTROL_CANID_PUMP, CONTROL_CANID_RADFAN };
 
+static uint16_t id_list_3[4] = { BMS_CANID_CELL_TEMPS };
+
 void init_can1(CAN_HandleTypeDef *hcan)
 {
 	assert(hcan);
@@ -45,6 +47,7 @@ void init_can1(CAN_HandleTypeDef *hcan)
 	assert(!can_init(can1));
 	assert(!can_add_filter_standard(can1, id_list_1));
 	assert(!can_add_filter_standard(can1, id_list_2));
+	assert(!can_add_filter_standard(can1, id_list_3));
 
 	can_outbound_queue =
 		osMessageQueueNew(CAN_MSG_QUEUE_SIZE, sizeof(can_msg_t), NULL);

--- a/Core/Src/can_handler.c
+++ b/Core/Src/can_handler.c
@@ -158,7 +158,6 @@ void vCanReceive(void *pv_params)
 		while (osOK ==
 		       osMessageQueueGet(can_inbound_queue, &msg, 0U, 0U)) {
 			switch (msg.id) {
-			/* Messages Relevant to Motor Controller */
 			case DTI_CANID_ERPM:
 				dti_record_rpm(mc, msg);
 				break;
@@ -167,6 +166,9 @@ void vCanReceive(void *pv_params)
 				break;
 			case BMS_DCL_MSG:
 				handle_dcl_msg();
+				break;
+			case BMS_CANID_CELL_TEMPS:
+				bms_record_battbox_temp(msg);
 				break;
 			case BUTTON_CANID_IO:
 				buttons_update(msg);

--- a/Core/Src/control.c
+++ b/Core/Src/control.c
@@ -111,6 +111,14 @@ void vControl(void *params)
 		.device_type = DEVICE_RADFAN1,
 	};
 
+	device_control_t fan_battbox = {
+		.pdu = pdu,
+		.control_func = write_fan_battbox,
+		.upper_temp = FANBATTBOX_UPPER_TEMP,
+		.lower_temp = FANBATTBOX_LOWER_TEMP,
+		.device_type = DEVICE_FANBATTBOX,
+	};
+
 	write_pump_1(pdu, false);
 	write_pump_2(pdu, false);
 
@@ -119,14 +127,15 @@ void vControl(void *params)
 		dti_get_motor_temp(mc, &motor_temp);
 		uint16_t controller_temp;
 		dti_get_controller_temp(mc, &controller_temp);
+		uint16_t battbox_temp;
+		bms_get_battbox_temp(&battbox_temp);
 
 		// Determine device state
 		control_device(&pump0, motor_temp);
 		control_device(&radfan0, motor_temp);
 		control_device(&pump1, controller_temp);
 		control_device(&radfan1, controller_temp);
-
-		write_fan_battbox(pdu, calypso_states[DEVICE_FANBATTBOX]);
+		control_device(&fan_battbox, battbox_temp);
 
 		osDelay(1000);
 	}

--- a/Core/Src/control.c
+++ b/Core/Src/control.c
@@ -3,6 +3,7 @@
 
 #include "control.h"
 #include "state_machine.h"
+#include <stdio.h>
 
 bool calypso_states[NUM_DEVICES];
 

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -177,6 +177,8 @@ int main(void)
 	assert(pdu);
 	dti_t *mc = dti_init();
 	assert(mc);
+  bms_t *bms = bms_init();
+  assert(bms);
 	init_can1(&hcan1);
 	init_bms();
 

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -177,10 +177,8 @@ int main(void)
 	assert(pdu);
 	dti_t *mc = dti_init();
 	assert(mc);
-  bms_t *bms = bms_init();
-  assert(bms);
 	init_can1(&hcan1);
-	init_bms();
+  bms_init();
 
 	printf("\n\n\nInit Success...\n\n\n");
 

--- a/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_can.c
+++ b/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_can.c
@@ -331,6 +331,8 @@ HAL_StatusTypeDef HAL_CAN_Init(CAN_HandleTypeDef *hcan)
   }
 #endif /* USE_HAL_CAN_REGISTER_CALLBACKS */
 
+  CLEAR_BIT(hcan->Instance->MCR, CAN_MCR_SLEEP);
+
   /* Request initialisation */
   SET_BIT(hcan->Instance->MCR, CAN_MCR_INRQ);
 

--- a/cerberus.resc
+++ b/cerberus.resc
@@ -48,3 +48,6 @@ sysbus.pumpsTempAdc FeedSample 0xFF 12 -1
 # To see the can messages emitted run `candump vcan0` on host in a separate terminal
 # To initialize the vcan run `sudo modprobe vcan` and then `sudo ip link add dev vcan0 type vcan` and `sudo ip link set up vcan0`
 # sudo docker run --rm --network=host -it -v $(pwd):/mnt -w /mnt antmicro/renode renode -e "include @/mnt/wheel.resc"
+# Changes you may have to make: Add the clear bit into stm32f4xx_hal_can.c around line 331   CLEAR_BIT(hcan->Instance->MCR, CAN_MCR_SLEEP);
+# Delete OS Delays in pdu init and others that occur before the task scheduler has been started
+

--- a/mpu.repl
+++ b/mpu.repl
@@ -1,8 +1,8 @@
 using "Drivers/Embedded-Base/dev/renode/cpus/stm32f405_ner.repl"
 
-pduGPIOPortShutdown: I2C.PCA9539 @ i2c2  0x75
+pduGPIOPortShutdown: I2C.PCA9539 @ i2c2  0x77
 
-pduGPIOPortCTRL: I2C.PCA9539 @ i2c2 0x74
+pduGPIOPortCTRL: I2C.PCA9539 @ i2c2 0x76
 
 motorControllerCurrentSensor: I2C.INA226 @ i2c2 0x40
 


### PR DESCRIPTION
## Changes
Added battbox fan control (to control.c) based on the BMS cell temp CAN message
- Added `bms_get_battbox_temp()` and `bms_record_battbox_temp()` to bms.c. These functions are used in can_handler.c and control.c.
- Also made small changes to how bms_init() works

## Notes
Not tested yet

## Checklist
- [x] No merge conflicts
- [x] All checks passing
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
